### PR TITLE
0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - WP_VERSION=trunk WP_MULTISITE=1
 
 install:
+    - nvm install 6 && nvm use 6
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
     - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-js-widgets",
 	"description": "The next generation of widgets in Core (Widgets 3.0), embracing JS for UI and powering the Widgets REST API.",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"type": "wordpress-plugin",
 	"keywords": [ "customizer", "widgets", "rest-api" ],
 	"homepage": "https://github.com/xwp/wp-js-widgets/",

--- a/core-adapter-widgets/archives/class.php
+++ b/core-adapter-widgets/archives/class.php
@@ -55,14 +55,12 @@ class WP_JS_Widget_Archives extends WP_Adapter_JS_Widget {
 	public function render_form_template() {
 		$this->render_title_form_field_template();
 		$this->render_form_field_template( array(
-			'name' => 'dropdown',
+			'field' => 'dropdown',
 			'label' => __( 'Display as dropdown', 'default' ),
-			'type' => 'checkbox',
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'count',
+			'field' => 'count',
 			'label' => __( 'Show post counts', 'default' ),
-			'type' => 'checkbox',
 		) );
 	}
 }

--- a/core-adapter-widgets/archives/class.php
+++ b/core-adapter-widgets/archives/class.php
@@ -50,25 +50,19 @@ class WP_JS_Widget_Archives extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template();
-			$this->render_form_field_template( array(
-				'name' => 'dropdown',
-				'label' => __( 'Display as dropdown', 'default' ),
-				'type' => 'checkbox',
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'count',
-				'label' => __( 'Show post counts', 'default' ),
-				'type' => 'checkbox',
-			) );
-			?>
-		</script>
-		<?php
+	public function render_form_template() {
+		$this->render_title_form_field_template();
+		$this->render_form_field_template( array(
+			'name' => 'dropdown',
+			'label' => __( 'Display as dropdown', 'default' ),
+			'type' => 'checkbox',
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'count',
+			'label' => __( 'Show post counts', 'default' ),
+			'type' => 'checkbox',
+		) );
 	}
 }

--- a/core-adapter-widgets/archives/class.php
+++ b/core-adapter-widgets/archives/class.php
@@ -28,7 +28,7 @@ class WP_JS_Widget_Archives extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'dropdown' => array(
@@ -46,7 +46,7 @@ class WP_JS_Widget_Archives extends WP_Adapter_JS_Widget {
 				// @todo There needs to be raw data returned such that a client can construct an archive view as get_archives() does on the server.
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/archives/form.js
+++ b/core-adapter-widgets/archives/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.archives = (function( api ) {
+wp.widgets.formConstructor.archives = (function() {
 	'use strict';
 
 	var ArchivesWidgetForm;
@@ -13,11 +13,13 @@ wp.customize.Widgets.formConstructor.archives = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	ArchivesWidgetForm = api.Widgets.Form.extend( {} );
+	ArchivesWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'archives'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = ArchivesWidgetForm;
 	}
 	return ArchivesWidgetForm;
 
-})( wp.customize );
+})();

--- a/core-adapter-widgets/calendar/class.php
+++ b/core-adapter-widgets/calendar/class.php
@@ -28,18 +28,18 @@ class WP_JS_Widget_Calendar extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = parent::get_item_schema();
-		$schema['title']['properties']['raw']['default'] = '';
+		$item_schema = parent::get_item_schema();
+		$item_schema['title']['properties']['raw']['default'] = '';
 
 		// @todo The underlying data that get_calendar() uses to render the calendar should be included instead.
-		$schema['rendered'] = array(
+		$item_schema['rendered'] = array(
 			'description' => __( 'The rendered HTML for the post calendar.', 'js-widgets' ),
 			'type' => 'string',
 			'context' => array( 'view', 'edit', 'embed' ),
 			'readonly' => true,
 			'default' => '',
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/calendar/form.js
+++ b/core-adapter-widgets/calendar/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor.calendar = (function() {
 	 *
 	 * @constructor
 	 */
-	CalendarWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'calendar'
-	} );
+	CalendarWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = CalendarWidgetForm;

--- a/core-adapter-widgets/calendar/form.js
+++ b/core-adapter-widgets/calendar/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.calendar = (function() {
+wp.widgets.formConstructor.calendar = (function() {
 	'use strict';
 
 	var CalendarWidgetForm;
@@ -13,7 +13,9 @@ wp.customize.Widgets.formConstructor.calendar = (function() {
 	 *
 	 * @constructor
 	 */
-	CalendarWidgetForm = wp.customize.Widgets.Form.extend( {} );
+	CalendarWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'calendar'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = CalendarWidgetForm;

--- a/core-adapter-widgets/categories/class.php
+++ b/core-adapter-widgets/categories/class.php
@@ -196,19 +196,16 @@ class WP_JS_Widget_Categories extends WP_Adapter_JS_Widget {
 			'placeholder' => $item_schema['title']['properties']['raw']['default'],
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'dropdown',
+			'field' => 'dropdown',
 			'label' => __( 'Display as dropdown', 'default' ),
-			'type' => 'checkbox',
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'count',
+			'field' => 'count',
 			'label' => __( 'Show post counts', 'default' ),
-			'type' => 'checkbox',
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'hierarchical',
+			'field' => 'hierarchical',
 			'label' => __( 'Show hierarchy', 'default' ),
-			'type' => 'checkbox',
 		) );
 	}
 }

--- a/core-adapter-widgets/categories/class.php
+++ b/core-adapter-widgets/categories/class.php
@@ -28,7 +28,7 @@ class WP_JS_Widget_Categories extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'dropdown' => array(
@@ -61,7 +61,7 @@ class WP_JS_Widget_Categories extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/categories/class.php
+++ b/core-adapter-widgets/categories/class.php
@@ -188,33 +188,27 @@ class WP_JS_Widget_Categories extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
 		$item_schema = $this->get_item_schema();
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template( array(
-				'placeholder' => $item_schema['title']['properties']['raw']['default'],
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'dropdown',
-				'label' => __( 'Display as dropdown', 'default' ),
-				'type' => 'checkbox',
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'count',
-				'label' => __( 'Show post counts', 'default' ),
-				'type' => 'checkbox',
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'hierarchical',
-				'label' => __( 'Show hierarchy', 'default' ),
-				'type' => 'checkbox',
-			) );
-			?>
-		</script>
-		<?php
+		$this->render_title_form_field_template( array(
+			'placeholder' => $item_schema['title']['properties']['raw']['default'],
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'dropdown',
+			'label' => __( 'Display as dropdown', 'default' ),
+			'type' => 'checkbox',
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'count',
+			'label' => __( 'Show post counts', 'default' ),
+			'type' => 'checkbox',
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'hierarchical',
+			'label' => __( 'Show hierarchy', 'default' ),
+			'type' => 'checkbox',
+		) );
 	}
 }

--- a/core-adapter-widgets/categories/form.js
+++ b/core-adapter-widgets/categories/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.categories = (function( api ) {
+wp.widgets.formConstructor.categories = (function() {
 	'use strict';
 
 	var CategoriesWidgetForm;
@@ -13,11 +13,13 @@ wp.customize.Widgets.formConstructor.categories = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	CategoriesWidgetForm = api.Widgets.Form.extend( {} );
+	CategoriesWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'categories'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = CategoriesWidgetForm;
 	}
 	return CategoriesWidgetForm;
 
-})( wp.customize );
+})();

--- a/core-adapter-widgets/meta/class.php
+++ b/core-adapter-widgets/meta/class.php
@@ -29,7 +29,7 @@ class WP_JS_Widget_Meta extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'meta_links' => array(
@@ -40,7 +40,7 @@ class WP_JS_Widget_Meta extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/meta/form.js
+++ b/core-adapter-widgets/meta/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor.meta = (function() {
 	 *
 	 * @constructor
 	 */
-	MetaWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'meta'
-	} );
+	MetaWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = MetaWidgetForm;

--- a/core-adapter-widgets/meta/form.js
+++ b/core-adapter-widgets/meta/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.meta = (function() {
+wp.widgets.formConstructor.meta = (function() {
 	'use strict';
 
 	var MetaWidgetForm;
@@ -13,7 +13,9 @@ wp.customize.Widgets.formConstructor.meta = (function() {
 	 *
 	 * @constructor
 	 */
-	MetaWidgetForm = wp.customize.Widgets.Form.extend( {} );
+	MetaWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'meta'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = MetaWidgetForm;

--- a/core-adapter-widgets/nav_menu/class.php
+++ b/core-adapter-widgets/nav_menu/class.php
@@ -45,34 +45,29 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
+		$this->render_title_form_field_template();
 		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
+		<div class="no-menus-message">
+			<p><?php echo sprintf( __( 'No menus have been created yet. <a href="%s">Create some</a>.', 'default' ), esc_attr( 'javascript: wp.customize.panel( "nav_menus" ).focus();' ) ); ?></p>
+		</div>
+		<div class="menu-selection">
 			<?php
-			$this->render_title_form_field_template();
+			$this->render_form_field_template( array(
+				'name' => 'nav_menu',
+				'label' => __( 'Select Menu:', 'default' ),
+				'type' => 'select',
+				'choices' => array(
+					'0' => html_entity_decode( __( '&mdash; Select &mdash;', 'default' ), ENT_QUOTES, 'utf-8' ),
+				),
+			) );
 			?>
-
-			<div class="no-menus-message">
-				<p><?php echo sprintf( __( 'No menus have been created yet. <a href="%s">Create some</a>.', 'default' ), esc_attr( 'javascript: wp.customize.panel( "nav_menus" ).focus();' ) ); ?></p>
-			</div>
-			<div class="menu-selection">
-				<?php
-				$this->render_form_field_template( array(
-					'name' => 'nav_menu',
-					'label' => __( 'Select Menu:', 'default' ),
-					'type' => 'select',
-					'choices' => array(
-						'0' => html_entity_decode( __( '&mdash; Select &mdash;', 'default' ), ENT_QUOTES, 'utf-8' ),
-					),
-				) );
-				?>
-				<p>
-					<button type="button" class="button edit"><?php esc_html_e( 'Edit Menu', 'default' ) ?></button>
-				</p>
-			</div>
-		</script>
+			<p>
+				<button type="button" class="button edit"><?php esc_html_e( 'Edit Menu', 'default' ) ?></button>
+			</p>
+		</div>
 		<?php
 	}
 }

--- a/core-adapter-widgets/nav_menu/class.php
+++ b/core-adapter-widgets/nav_menu/class.php
@@ -71,7 +71,7 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 		<div class="menu-selection">
 			<?php
 			$this->render_form_field_template( array(
-				'name' => 'nav_menu',
+				'field' => 'nav_menu',
 				'label' => __( 'Select Menu:', 'default' ),
 				'type' => 'select',
 				'choices' => array(

--- a/core-adapter-widgets/nav_menu/class.php
+++ b/core-adapter-widgets/nav_menu/class.php
@@ -51,7 +51,10 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 		$this->render_title_form_field_template();
 		?>
 		<div class="no-menus-message">
-			<p><?php echo sprintf( __( 'No menus have been created yet. <a href="%s">Create some</a>.', 'default' ), esc_attr( 'javascript: wp.customize.panel( "nav_menus" ).focus();' ) ); ?></p>
+			<p><?php
+			/* translators: %s is javascript link to nav_menus panel */
+			echo sprintf( __( 'No menus have been created yet. <a href="%s">Create some</a>.', 'default' ), esc_attr( 'javascript: wp.customize.panel( "nav_menus" ).focus();' ) );
+			?></p>
 		</div>
 		<div class="menu-selection">
 			<?php

--- a/core-adapter-widgets/nav_menu/class.php
+++ b/core-adapter-widgets/nav_menu/class.php
@@ -57,15 +57,36 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 	}
 
 	/**
+	 * Get data to pass to the JS form.
+	 *
+	 * @return array
+	 */
+	public function get_form_config() {
+		$config = parent::get_form_config();
+		$config['nav_menus'] = array();
+		foreach ( wp_get_nav_menus() as $nav_menu ) {
+			$config['nav_menus'][ $nav_menu->term_id ] = $nav_menu->name;
+		}
+		$config['nav_menu_edit_url'] = admin_url( 'nav-menus.php?action=edit&menu=%d' );
+		return $config;
+	}
+
+	/**
 	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
 	public function render_form_template() {
+		global $pagenow;
 		$this->render_title_form_field_template();
 		?>
 		<div class="no-menus-message">
 			<p><?php
+			if ( isset( $pagenow ) && 'customize.php' === $pagenow ) {
+				$url = 'javascript: wp.customize.panel( "nav_menus" ).focus();';
+			} else {
+				$url = admin_url( 'nav-menus.php' );
+			}
 			/* translators: %s is javascript link to nav_menus panel */
-			echo sprintf( __( 'No menus have been created yet. <a href="%s">Create some</a>.', 'default' ), esc_attr( 'javascript: wp.customize.panel( "nav_menus" ).focus();' ) );
+			echo sprintf( __( 'No menus have been created yet. <a href="%s">Create some</a>.', 'default' ), esc_attr( $url ) );
 			?></p>
 		</div>
 		<div class="menu-selection">

--- a/core-adapter-widgets/nav_menu/class.php
+++ b/core-adapter-widgets/nav_menu/class.php
@@ -25,6 +25,18 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 	}
 
 	/**
+	 * Register scripts.
+	 *
+	 * @param WP_Scripts $wp_scripts Scripts.
+	 */
+	public function register_scripts( $wp_scripts ) {
+		parent::register_scripts( $wp_scripts );
+
+		$handle = "widget-form-{$this->id_base}";
+		$wp_scripts->registered[ $handle ]->deps[] = 'backbone';
+	}
+
+	/**
 	 * Get instance schema properties.
 	 *
 	 * @return array Schema.

--- a/core-adapter-widgets/nav_menu/class.php
+++ b/core-adapter-widgets/nav_menu/class.php
@@ -42,7 +42,7 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'nav_menu' => array(
@@ -53,7 +53,8 @@ class WP_JS_Widget_Nav_Menu extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		$item_schema['title']['properties']['raw']['default'] = '';
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/nav_menu/form.js
+++ b/core-adapter-widgets/nav_menu/form.js
@@ -2,6 +2,7 @@
 /* eslint consistent-this: [ "error", "form" ] */
 /* eslint-disable strict */
 /* eslint-disable complexity */
+/* eslint no-magic-numbers: [ "error", {"ignore":[0,1]} ] */
 
 /*
  * The logic in the nav_menu form can replace the nav_menu JS that is currently strewn across customize-widgets.js and customize-nav-menus.js
@@ -101,6 +102,13 @@ wp.widgets.formConstructor.nav_menu = (function( api, $ ) {
 			var form = this;
 			wp.widgets.Form.prototype.initialize.call( form, properties );
 			_.bindAll( form, 'updateForm', 'handleEditButtonClick' );
+
+			if ( _.isObject( form.config.nav_menus ) && 0 === classProps.navMenuCollection.length ) {
+				_.each( form.config.nav_menus, function( name, id ) {
+					var navMenu = new classProps.NavMenuModel( { id: id, name: name } );
+					classProps.navMenuCollection.add( navMenu );
+				} );
+			}
 		},
 
 		/**
@@ -142,9 +150,16 @@ wp.widgets.formConstructor.nav_menu = (function( api, $ ) {
 		handleEditButtonClick: function handleEditButtonClick() {
 			var form = this, navMenuId, section;
 			navMenuId = form.getValue().nav_menu;
-			section = api.section( 'nav_menu[' + String( navMenuId ) + ']' );
-			if ( section ) {
-				section.focus();
+			if ( ! navMenuId || navMenuId < 1 ) {
+				return;
+			}
+			if ( api.section ) {
+				section = api.section( 'nav_menu[' + String( navMenuId ) + ']' );
+				if ( section ) {
+					section.focus();
+				}
+			} else {
+				window.open( form.config.nav_menu_edit_url.replace( '%d', String( navMenuId ) ) );
 			}
 		},
 

--- a/core-adapter-widgets/nav_menu/form.js
+++ b/core-adapter-widgets/nav_menu/form.js
@@ -13,7 +13,7 @@
  * https://github.com/xwp/wordpress-develop/blob/1aec30fba8201b6d8a76cc64b16c96f2f4d6fe4f/src/wp-admin/js/customize-nav-menus.js#L2895-L2906
  * https://github.com/xwp/wordpress-develop/blob/1aec30fba8201b6d8a76cc64b16c96f2f4d6fe4f/src/wp-admin/js/customize-nav-menus.js#L2919-L2929
  */
-wp.customize.Widgets.formConstructor.nav_menu = (function( api, $ ) {
+wp.widgets.formConstructor.nav_menu = (function( api, $ ) {
 	'use strict';
 
 	var NavMenuWidgetForm, classProps = {};
@@ -89,7 +89,9 @@ wp.customize.Widgets.formConstructor.nav_menu = (function( api, $ ) {
 	 *
 	 * @constructor
 	 */
-	NavMenuWidgetForm = api.Widgets.Form.extend( {
+	NavMenuWidgetForm = wp.widgets.Form.extend( {
+
+		id_base: 'nav_menu',
 
 		/**
 		 * Initialize.
@@ -99,7 +101,7 @@ wp.customize.Widgets.formConstructor.nav_menu = (function( api, $ ) {
 		 */
 		initialize: function initialize( properties ) {
 			var form = this;
-			api.Widgets.Form.prototype.initialize.call( form, properties );
+			wp.widgets.Form.prototype.initialize.call( form, properties );
 			_.bindAll( form, 'updateForm', 'handleEditButtonClick' );
 		},
 
@@ -110,7 +112,7 @@ wp.customize.Widgets.formConstructor.nav_menu = (function( api, $ ) {
 		 */
 		render: function render() {
 			var form = this;
-			api.Widgets.Form.prototype.render.call( form );
+			wp.widgets.Form.prototype.render.call( form );
 			NavMenuWidgetForm.navMenuCollection.on( 'update change', form.updateForm );
 			form.container.find( 'button.edit' ).on( 'click', form.handleEditButtonClick );
 			form.noMenusMessage = form.container.find( '.no-menus-message' );
@@ -129,7 +131,7 @@ wp.customize.Widgets.formConstructor.nav_menu = (function( api, $ ) {
 			NavMenuWidgetForm.navMenuCollection.off( 'update change', form.updateForm );
 			form.noMenusMessage = null;
 			form.menuSelection = null;
-			api.Widgets.Form.prototype.destruct.call( form );
+			wp.widgets.Form.prototype.destruct.call( form );
 		},
 
 		/**

--- a/core-adapter-widgets/nav_menu/form.js
+++ b/core-adapter-widgets/nav_menu/form.js
@@ -91,8 +91,6 @@ wp.widgets.formConstructor.nav_menu = (function( api, $ ) {
 	 */
 	NavMenuWidgetForm = wp.widgets.Form.extend( {
 
-		id_base: 'nav_menu',
-
 		/**
 		 * Initialize.
 		 *

--- a/core-adapter-widgets/pages/class.php
+++ b/core-adapter-widgets/pages/class.php
@@ -209,7 +209,7 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 			'placeholder' => $item_schema['title']['properties']['raw']['default'],
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'sortby',
+			'field' => 'sortby',
 			'label' => __( 'Sort by:', 'default' ),
 			'type' => 'select',
 			'choices' => array(
@@ -226,9 +226,8 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 			</p>
 		<?php else :
 			$this->render_form_field_template( array(
-				'name' => 'exclude',
+				'field' => 'exclude',
 				'label' => __( 'Exclude:', 'default' ),
-				'type' => 'text',
 				'pattern' => self::ID_LIST_PATTERN,
 				'title' => __( 'Page IDs, separated by commas.', 'default' ),
 				'help' => __( 'Page IDs, separated by commas.', 'default' ),

--- a/core-adapter-widgets/pages/class.php
+++ b/core-adapter-widgets/pages/class.php
@@ -201,43 +201,38 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
 		$item_schema = $this->get_item_schema();
+		$this->render_title_form_field_template( array(
+			'placeholder' => $item_schema['title']['properties']['raw']['default'],
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'sortby',
+			'label' => __( 'Sort by:', 'default' ),
+			'type' => 'select',
+			'choices' => array(
+				'post_title' => __( 'Page title', 'default' ),
+				'menu_order' => __( 'Page order', 'default' ),
+				'ID' => __( 'Page ID', 'default' ),
+			),
+		) );
 		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template( array(
-				'placeholder' => $item_schema['title']['properties']['raw']['default'],
-			) );
+		<?php if ( wp_scripts()->query( 'customize-object-selector-component' ) ) : ?>
+			<p class="exclude-pages-selector">
+				<label for="{{ data.config.exclude_select_id }}"><?php esc_html_e( 'Exclude:', 'default' ) ?></label>
+				<span class="customize-object-selector-container"></span>
+			</p>
+		<?php else :
 			$this->render_form_field_template( array(
-				'name' => 'sortby',
-				'label' => __( 'Sort by:', 'default' ),
-				'type' => 'select',
-				'choices' => array(
-					'post_title' => __( 'Page title', 'default' ),
-					'menu_order' => __( 'Page order', 'default' ),
-					'ID' => __( 'Page ID', 'default' ),
-				),
+				'name' => 'exclude',
+				'label' => __( 'Exclude:', 'default' ),
+				'type' => 'text',
+				'pattern' => self::ID_LIST_PATTERN,
+				'title' => __( 'Page IDs, separated by commas.', 'default' ),
+				'help' => __( 'Page IDs, separated by commas.', 'default' ),
 			) );
-			?>
-			<?php if ( wp_scripts()->query( 'customize-object-selector-component' ) ) : ?>
-				<p class="exclude-pages-selector">
-					<label for="{{ data.config.exclude_select_id }}"><?php esc_html_e( 'Exclude:', 'default' ) ?></label>
-					<span class="customize-object-selector-container"></span>
-				</p>
-			<?php else :
-				$this->render_form_field_template( array(
-					'name' => 'exclude',
-					'label' => __( 'Exclude:', 'default' ),
-					'type' => 'text',
-					'pattern' => self::ID_LIST_PATTERN,
-					'title' => __( 'Page IDs, separated by commas.', 'default' ),
-					'help' => __( 'Page IDs, separated by commas.', 'default' ),
-				) );
-			endif; ?>
-		</script>
-		<?php
+		endif;
 	}
 }

--- a/core-adapter-widgets/pages/class.php
+++ b/core-adapter-widgets/pages/class.php
@@ -42,7 +42,7 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 				),
 				'exclude' => array(
 					'description' => __( 'Page IDs to exclude.', 'js-widgets' ),
-					'type' => 'array',
+					'type' => array( 'array', 'string' ),
 					'items' => array(
 						'type' => 'integer',
 					),
@@ -81,6 +81,25 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 			return $validity;
 		}
 		return join( ',', wp_parse_id_list( $value ) ); // String as needed by WP_Widget_Pages.
+	}
+
+	/**
+	 * Sanitize instance data.
+	 *
+	 * @inheritdoc
+	 *
+	 * @param array $new_instance  New instance.
+	 * @param array $old_instance  Old instance.
+	 * @return array|null|WP_Error Array instance if sanitization (and validation) passed. Returns `WP_Error` or `null` on failure.
+	 */
+	public function sanitize( $new_instance, $old_instance ) {
+		$default_instance = $this->get_default_instance();
+		if ( is_array( $default_instance['exclude'] ) ) {
+			$default_instance['exclude'] = join( ',', $default_instance['exclude'] );
+		}
+		$new_instance = array_merge( $default_instance, $new_instance );
+		$old_instance = array_merge( $default_instance, $old_instance );
+		return parent::sanitize( $new_instance, $old_instance );
 	}
 
 	/**

--- a/core-adapter-widgets/pages/class.php
+++ b/core-adapter-widgets/pages/class.php
@@ -30,7 +30,7 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'sortby' => array(
@@ -61,7 +61,7 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/pages/class.php
+++ b/core-adapter-widgets/pages/class.php
@@ -97,6 +97,9 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 		if ( is_array( $default_instance['exclude'] ) ) {
 			$default_instance['exclude'] = join( ',', $default_instance['exclude'] );
 		}
+		if ( is_array( $new_instance['exclude'] ) ) {
+			$new_instance['exclude'] = join( ',', $new_instance['exclude'] );
+		}
 		$new_instance = array_merge( $default_instance, $new_instance );
 		$old_instance = array_merge( $default_instance, $old_instance );
 		return parent::sanitize( $new_instance, $old_instance );

--- a/core-adapter-widgets/pages/form.js
+++ b/core-adapter-widgets/pages/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.pages = (function( api ) {
+wp.widgets.formConstructor.pages = (function( api ) {
 	'use strict';
 
 	var PagesWidgetForm;
@@ -13,24 +13,22 @@ wp.customize.Widgets.formConstructor.pages = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	PagesWidgetForm = wp.customize.Widgets.Form.extend( {
+	PagesWidgetForm = wp.widgets.Form.extend( {
+
+		id_base: 'pages',
 
 		/**
 		 * Initialize.
 		 *
-		 * @param {object}                             properties         Properties.
-		 * @param {wp.customize.Widgets.WidgetControl} properties.control Customize control.
-		 * @param {object}                             properties.config  Form config.
+		 * @param {object} properties Properties.
 		 * @return {void}
 		 */
 		initialize: function initializePagesWidgetForm( properties ) {
-			var form = this, props;
+			var form = this;
 
-			props = _.clone( properties );
-			props.config = _.clone( props.config );
-			props.config.exclude_select_id = 'select' + String( Math.random() );
+			wp.widgets.Form.prototype.initialize.call( form, properties );
 
-			api.Widgets.Form.prototype.initialize.call( form, props );
+			form.config.exclude_select_id = 'select' + String( Math.random() );
 		},
 
 		/**
@@ -41,7 +39,7 @@ wp.customize.Widgets.formConstructor.pages = (function( api ) {
 		 */
 		render: function render() {
 			var form = this, selectorContainer;
-			api.Widgets.Form.prototype.render.call( form );
+			wp.widgets.Form.prototype.render.call( form );
 
 			if ( api.ObjectSelectorComponent ) {
 				form.postObjectSelector = new api.ObjectSelectorComponent({
@@ -69,7 +67,7 @@ wp.customize.Widgets.formConstructor.pages = (function( api ) {
 		linkPropertyElements: function linkPropertyElements() {
 			var form = this, excludeIds;
 
-			api.Widgets.Form.prototype.linkPropertyElements.call( form );
+			wp.widgets.Form.prototype.linkPropertyElements.call( form );
 			if ( api.ObjectSelectorComponent ) {
 
 				// Quietly convert the exclude property from comma-separated list string to ID array, as required by Customize Object Selector.

--- a/core-adapter-widgets/pages/form.js
+++ b/core-adapter-widgets/pages/form.js
@@ -68,19 +68,23 @@ wp.widgets.formConstructor.pages = (function( api ) {
 			wp.widgets.Form.prototype.linkPropertyElements.call( form );
 			if ( api.ObjectSelectorComponent ) {
 
-				// Quietly convert the exclude property from comma-separated list string to ID array, as required by Customize Object Selector.
+				/*
+				 * Quietly convert the exclude property from comma-separated list
+				 * string to ID array, as required by Customize Object Selector.
+				 * This prevents the setting from being marked as dirty upon init.
+				 */
 				excludeIds = [];
-				if ( form.setting._value.exclude ) {
-					_.each( form.setting._value.exclude.split( /\s*,\s*/ ), function( value ) {
+				if ( form.model._value.exclude && _.isString( form.model._value.exclude ) ) {
+					_.each( form.model._value.exclude.split( /\s*,\s*/ ), function( value ) {
 						var id = parseInt( value, 10 );
 						if ( ! isNaN( id ) ) {
 							excludeIds.push( id );
 						}
 					} );
 				}
-				form.setting._value.exclude = excludeIds;
+				form.model._value.exclude = excludeIds;
 
-				form.syncedProperties.exclude = form.createSyncedPropertyValue( form.setting, 'exclude' );
+				form.syncedProperties.exclude = form.createSyncedPropertyValue( form.model, 'exclude' );
 			}
 		}
 	} );

--- a/core-adapter-widgets/pages/form.js
+++ b/core-adapter-widgets/pages/form.js
@@ -15,8 +15,6 @@ wp.widgets.formConstructor.pages = (function( api ) {
 	 */
 	PagesWidgetForm = wp.widgets.Form.extend( {
 
-		id_base: 'pages',
-
 		/**
 		 * Initialize.
 		 *

--- a/core-adapter-widgets/recent-comments/class.php
+++ b/core-adapter-widgets/recent-comments/class.php
@@ -113,10 +113,8 @@ class WP_JS_Widget_Recent_Comments extends WP_Adapter_JS_Widget {
 			'placeholder' => $item_schema['title']['properties']['raw']['default'],
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'number',
+			'field' => 'number',
 			'label' => __( 'Number of comments to show:', 'default' ),
-			'type' => 'number',
-			'min' => $item_schema['number']['minimum'],
 		) );
 	}
 }

--- a/core-adapter-widgets/recent-comments/class.php
+++ b/core-adapter-widgets/recent-comments/class.php
@@ -28,7 +28,7 @@ class WP_JS_Widget_Recent_Comments extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'number' => array(
@@ -50,7 +50,7 @@ class WP_JS_Widget_Recent_Comments extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/recent-comments/class.php
+++ b/core-adapter-widgets/recent-comments/class.php
@@ -105,24 +105,18 @@ class WP_JS_Widget_Recent_Comments extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
 		$item_schema = $this->get_item_schema();
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template( array(
-				'placeholder' => $item_schema['title']['properties']['raw']['default'],
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'number',
-				'label' => __( 'Number of comments to show:', 'default' ),
-				'type' => 'number',
-				'min' => $item_schema['number']['minimum'],
-			) );
-			?>
-		</script>
-		<?php
+		$this->render_title_form_field_template( array(
+			'placeholder' => $item_schema['title']['properties']['raw']['default'],
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'number',
+			'label' => __( 'Number of comments to show:', 'default' ),
+			'type' => 'number',
+			'min' => $item_schema['number']['minimum'],
+		) );
 	}
 }

--- a/core-adapter-widgets/recent-comments/form.js
+++ b/core-adapter-widgets/recent-comments/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor['recent-comments'] = (function() {
 	 *
 	 * @constructor
 	 */
-	RecentCommentsWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'recent-comments'
-	} );
+	RecentCommentsWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = RecentCommentsWidgetForm;

--- a/core-adapter-widgets/recent-comments/form.js
+++ b/core-adapter-widgets/recent-comments/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor['recent-comments'] = (function( api ) {
+wp.widgets.formConstructor['recent-comments'] = (function() {
 	'use strict';
 
 	var RecentCommentsWidgetForm;
@@ -13,11 +13,13 @@ wp.customize.Widgets.formConstructor['recent-comments'] = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	RecentCommentsWidgetForm = api.Widgets.Form.extend( {} );
+	RecentCommentsWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'recent-comments'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = RecentCommentsWidgetForm;
 	}
 	return RecentCommentsWidgetForm;
 
-})( wp.customize );
+})();

--- a/core-adapter-widgets/recent-posts/class.php
+++ b/core-adapter-widgets/recent-posts/class.php
@@ -28,7 +28,7 @@ class WP_JS_Widget_Recent_Posts extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'number' => array(
@@ -56,7 +56,7 @@ class WP_JS_Widget_Recent_Posts extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/recent-posts/class.php
+++ b/core-adapter-widgets/recent-posts/class.php
@@ -128,29 +128,23 @@ class WP_JS_Widget_Recent_Posts extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
 		$item_schema = $this->get_item_schema();
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template( array(
-				'placeholder' => $item_schema['title']['properties']['raw']['default'],
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'number',
-				'label' => __( 'Number of posts to show:', 'default' ),
-				'type' => 'number',
-				'min' => $item_schema['number']['minimum'],
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'show_date',
-				'label' => __( 'Display post date?', 'default' ),
-				'type' => 'checkbox',
-			) );
-			?>
-		</script>
-		<?php
+		$this->render_title_form_field_template( array(
+			'placeholder' => $item_schema['title']['properties']['raw']['default'],
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'number',
+			'label' => __( 'Number of posts to show:', 'default' ),
+			'type' => 'number',
+			'min' => $item_schema['number']['minimum'],
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'show_date',
+			'label' => __( 'Display post date?', 'default' ),
+			'type' => 'checkbox',
+		) );
 	}
 }

--- a/core-adapter-widgets/recent-posts/class.php
+++ b/core-adapter-widgets/recent-posts/class.php
@@ -136,15 +136,12 @@ class WP_JS_Widget_Recent_Posts extends WP_Adapter_JS_Widget {
 			'placeholder' => $item_schema['title']['properties']['raw']['default'],
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'number',
+			'field' => 'number',
 			'label' => __( 'Number of posts to show:', 'default' ),
-			'type' => 'number',
-			'min' => $item_schema['number']['minimum'],
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'show_date',
+			'field' => 'show_date',
 			'label' => __( 'Display post date?', 'default' ),
-			'type' => 'checkbox',
 		) );
 	}
 }

--- a/core-adapter-widgets/recent-posts/form.js
+++ b/core-adapter-widgets/recent-posts/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor['recent-posts'] = (function() {
 	 *
 	 * @constructor
 	 */
-	RecentPostsWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'recent-posts'
-	} );
+	RecentPostsWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = RecentPostsWidgetForm;

--- a/core-adapter-widgets/recent-posts/form.js
+++ b/core-adapter-widgets/recent-posts/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor['recent-posts'] = (function( api ) {
+wp.widgets.formConstructor['recent-posts'] = (function() {
 	'use strict';
 
 	var RecentPostsWidgetForm;
@@ -13,11 +13,13 @@ wp.customize.Widgets.formConstructor['recent-posts'] = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	RecentPostsWidgetForm = api.Widgets.Form.extend( {} );
+	RecentPostsWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'recent-posts'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = RecentPostsWidgetForm;
 	}
 	return RecentPostsWidgetForm;
 
-})( wp.customize );
+})();

--- a/core-adapter-widgets/rss/class.php
+++ b/core-adapter-widgets/rss/class.php
@@ -235,36 +235,28 @@ class WP_JS_Widget_RSS extends WP_Adapter_JS_Widget {
 	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
 	public function render_form_template() {
-		$item_schema = $this->get_item_schema();
 		$this->render_form_field_template( array(
-			'name' => 'url',
+			'field' => 'url',
 			'label' => __( 'Enter the RSS feed URL here:', 'default' ),
-			'type' => 'url',
 		) );
 		$this->render_title_form_field_template( array(
 			'label' => __( 'Give the feed a title (optional)', 'default' ),
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'items',
+			'field' => 'items',
 			'label' => __( 'How many items would you like to display?', 'default' ),
-			'type' => 'number',
-			'min' => $item_schema['items']['minimum'],
-			'max' => $item_schema['items']['maximum'],
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'show_summary',
+			'field' => 'show_summary',
 			'label' => __( 'Display item content?', 'default' ),
-			'type' => 'checkbox',
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'show_author',
+			'field' => 'show_author',
 			'label' => __( 'Display item author if available?', 'default' ),
-			'type' => 'checkbox',
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'show_date',
+			'field' => 'show_date',
 			'label' => __( 'Display item date?', 'default' ),
-			'type' => 'checkbox',
 		) );
 	}
 }

--- a/core-adapter-widgets/rss/class.php
+++ b/core-adapter-widgets/rss/class.php
@@ -232,45 +232,39 @@ class WP_JS_Widget_RSS extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
 		$item_schema = $this->get_item_schema();
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_form_field_template( array(
-				'name' => 'url',
-				'label' => __( 'Enter the RSS feed URL here:', 'default' ),
-				'type' => 'url',
-			) );
-			$this->render_title_form_field_template( array(
-				'label' => __( 'Give the feed a title (optional)', 'default' ),
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'items',
-				'label' => __( 'How many items would you like to display?', 'default' ),
-				'type' => 'number',
-				'min' => $item_schema['items']['minimum'],
-				'max' => $item_schema['items']['maximum'],
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'show_summary',
-				'label' => __( 'Display item content?', 'default' ),
-				'type' => 'checkbox',
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'show_author',
-				'label' => __( 'Display item author if available?', 'default' ),
-				'type' => 'checkbox',
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'show_date',
-				'label' => __( 'Display item date?', 'default' ),
-				'type' => 'checkbox',
-			) );
-			?>
-		</script>
-		<?php
+		$this->render_form_field_template( array(
+			'name' => 'url',
+			'label' => __( 'Enter the RSS feed URL here:', 'default' ),
+			'type' => 'url',
+		) );
+		$this->render_title_form_field_template( array(
+			'label' => __( 'Give the feed a title (optional)', 'default' ),
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'items',
+			'label' => __( 'How many items would you like to display?', 'default' ),
+			'type' => 'number',
+			'min' => $item_schema['items']['minimum'],
+			'max' => $item_schema['items']['maximum'],
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'show_summary',
+			'label' => __( 'Display item content?', 'default' ),
+			'type' => 'checkbox',
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'show_author',
+			'label' => __( 'Display item author if available?', 'default' ),
+			'type' => 'checkbox',
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'show_date',
+			'label' => __( 'Display item date?', 'default' ),
+			'type' => 'checkbox',
+		) );
 	}
 }

--- a/core-adapter-widgets/rss/class.php
+++ b/core-adapter-widgets/rss/class.php
@@ -101,7 +101,7 @@ class WP_JS_Widget_RSS extends WP_Adapter_JS_Widget {
 	function validate_feed_url( $url, $request, $param ) {
 		$validity = rest_validate_request_arg( $url, $request, $param );
 		if ( true === $validity ) {
-			if ( ! esc_url_raw( $url, array( 'http', 'https' ) ) ) {
+			if ( ! empty( $url ) && ! esc_url_raw( $url, array( 'http', 'https' ) ) ) {
 				return new WP_Error( 'invalid_url_protocol', __( 'Invalid URL protocol. Expected HTTP or HTTPS.', 'js-widgets' ) );
 			}
 		}

--- a/core-adapter-widgets/rss/class.php
+++ b/core-adapter-widgets/rss/class.php
@@ -28,7 +28,7 @@ class WP_JS_Widget_RSS extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'url' => array(
@@ -86,8 +86,8 @@ class WP_JS_Widget_RSS extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		$schema['title']['properties']['raw']['default'] = '';
-		return $schema;
+		$item_schema['title']['properties']['raw']['default'] = '';
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/rss/form.js
+++ b/core-adapter-widgets/rss/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor.rss = (function() {
 	 *
 	 * @constructor
 	 */
-	RSSWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'rss'
-	} );
+	RSSWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = RSSWidgetForm;

--- a/core-adapter-widgets/rss/form.js
+++ b/core-adapter-widgets/rss/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.rss = (function( api ) {
+wp.widgets.formConstructor.rss = (function() {
 	'use strict';
 
 	var RSSWidgetForm;
@@ -13,11 +13,13 @@ wp.customize.Widgets.formConstructor.rss = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	RSSWidgetForm = api.Widgets.Form.extend( {} );
+	RSSWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'rss'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = RSSWidgetForm;
 	}
 	return RSSWidgetForm;
 
-})( wp.customize );
+})();

--- a/core-adapter-widgets/search/class.php
+++ b/core-adapter-widgets/search/class.php
@@ -30,8 +30,8 @@ class WP_JS_Widget_Search extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = parent::get_item_schema();
+		$item_schema = parent::get_item_schema();
 		$item_schema['title']['properties']['raw']['default'] = '';
-		return $schema;
+		return $item_schema;
 	}
 }

--- a/core-adapter-widgets/search/form.js
+++ b/core-adapter-widgets/search/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.search = (function() {
+wp.widgets.formConstructor.search = (function() {
 	'use strict';
 
 	var SearchWidgetForm;
@@ -13,7 +13,9 @@ wp.customize.Widgets.formConstructor.search = (function() {
 	 *
 	 * @constructor
 	 */
-	SearchWidgetForm = wp.customize.Widgets.Form.extend( {} );
+	SearchWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'search'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = SearchWidgetForm;

--- a/core-adapter-widgets/search/form.js
+++ b/core-adapter-widgets/search/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor.search = (function() {
 	 *
 	 * @constructor
 	 */
-	SearchWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'search'
-	} );
+	SearchWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = SearchWidgetForm;

--- a/core-adapter-widgets/tag_cloud/class.php
+++ b/core-adapter-widgets/tag_cloud/class.php
@@ -34,7 +34,7 @@ class WP_JS_Widget_Tag_Cloud extends WP_Adapter_JS_Widget {
 		}
 		$taxonomies = array_values( $taxonomies );
 
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'taxonomy' => array(
@@ -59,8 +59,8 @@ class WP_JS_Widget_Tag_Cloud extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		$schema['title']['properties']['raw']['default'] = '';
-		return $schema;
+		$item_schema['title']['properties']['raw']['default'] = '';
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/tag_cloud/class.php
+++ b/core-adapter-widgets/tag_cloud/class.php
@@ -167,34 +167,28 @@ class WP_JS_Widget_Tag_Cloud extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
+	public function render_form_template() {
 		$item_schema = $this->get_item_schema();
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template( array(
-				'placeholder' => $item_schema['title']['properties']['raw']['default'],
+		$this->render_title_form_field_template( array(
+			'placeholder' => $item_schema['title']['properties']['raw']['default'],
+		) );
+		$taxonomies = get_taxonomies( array( 'show_tagcloud' => true ), 'object' );
+		if ( ! get_option( 'link_manager_enabled' ) ) {
+			unset( $taxonomies['link_category'] );
+		}
+		if ( count( $taxonomies ) > 1 ) {
+			$taxonomy_choices = array();
+			foreach ( $taxonomies as $taxonomy ) {
+				$taxonomy_choices[ $taxonomy->name ] = $taxonomy->label;
+			}
+			$this->render_form_field_template( array(
+				'name' => 'taxonomy',
+				'label' => __( 'Taxonomy:', 'default' ),
+				'type' => 'select',
+				'choices' => $taxonomy_choices,
 			) );
-			$taxonomies = get_taxonomies( array( 'show_tagcloud' => true ), 'object' );
-			if ( ! get_option( 'link_manager_enabled' ) ) {
-				unset( $taxonomies['link_category'] );
-			}
-			if ( count( $taxonomies ) > 1 ) {
-				$taxonomy_choices = array();
-				foreach ( $taxonomies as $taxonomy ) {
-					$taxonomy_choices[ $taxonomy->name ] = $taxonomy->label;
-				}
-				$this->render_form_field_template( array(
-					'name' => 'taxonomy',
-					'label' => __( 'Taxonomy:', 'default' ),
-					'type' => 'select',
-					'choices' => $taxonomy_choices,
-				) );
-			}
-			?>
-		</script>
-		<?php
+		}
 	}
 }

--- a/core-adapter-widgets/tag_cloud/form.js
+++ b/core-adapter-widgets/tag_cloud/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.tag_cloud = (function( api ) {
+wp.widgets.formConstructor.tag_cloud = (function() {
 	'use strict';
 
 	var TagCloudWidgetForm;
@@ -13,11 +13,13 @@ wp.customize.Widgets.formConstructor.tag_cloud = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	TagCloudWidgetForm = api.Widgets.Form.extend( {} );
+	TagCloudWidgetForm = wp.widgets.Form.extend( {
+		id_base: 'tag_cloud'
+	} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = TagCloudWidgetForm;
 	}
 	return TagCloudWidgetForm;
 
-})( wp.customize );
+})();

--- a/core-adapter-widgets/tag_cloud/form.js
+++ b/core-adapter-widgets/tag_cloud/form.js
@@ -13,9 +13,7 @@ wp.widgets.formConstructor.tag_cloud = (function() {
 	 *
 	 * @constructor
 	 */
-	TagCloudWidgetForm = wp.widgets.Form.extend( {
-		id_base: 'tag_cloud'
-	} );
+	TagCloudWidgetForm = wp.widgets.Form.extend( {} );
 
 	if ( 'undefined' !== typeof module ) {
 		module.exports = TagCloudWidgetForm;

--- a/core-adapter-widgets/text/class.php
+++ b/core-adapter-widgets/text/class.php
@@ -100,16 +100,15 @@ class WP_JS_Widget_Text extends WP_Adapter_JS_Widget {
 	public function render_form_template() {
 		$this->render_title_form_field_template();
 		$this->render_form_field_template( array(
-			'name' => 'text',
+			'field' => 'text',
 			'label' => __( 'Content:', 'default' ),
 			'type' => 'textarea',
 			'rows' => 16,
 			'cols' => 20,
 		) );
 		$this->render_form_field_template( array(
-			'name' => 'filter',
+			'field' => 'filter',
 			'label' => __( 'Automatically add paragraphs', 'default' ),
-			'type' => 'checkbox',
 		) );
 	}
 

--- a/core-adapter-widgets/text/class.php
+++ b/core-adapter-widgets/text/class.php
@@ -118,8 +118,8 @@ class WP_JS_Widget_Text extends WP_Adapter_JS_Widget {
 	 *
 	 * @return array
 	 */
-	public function get_form_args() {
-		$args = parent::get_form_args();
+	public function get_form_config() {
+		$args = parent::get_form_config();
 		$args['can_unfiltered_html'] = current_user_can( 'unfiltered_html' );
 		$args['l10n'] = array_merge(
 			$args['l10n'],

--- a/core-adapter-widgets/text/class.php
+++ b/core-adapter-widgets/text/class.php
@@ -95,30 +95,22 @@ class WP_JS_Widget_Text extends WP_Adapter_JS_Widget {
 	}
 
 	/**
-	 * Render JS Template.
-	 *
-	 * This template is intended to be agnostic to the JS template technology used.
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
 	 */
-	public function form_template() {
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php
-			$this->render_title_form_field_template();
-			$this->render_form_field_template( array(
-				'name' => 'text',
-				'label' => __( 'Content:', 'default' ),
-				'type' => 'textarea',
-				'rows' => 16,
-				'cols' => 20,
-			) );
-			$this->render_form_field_template( array(
-				'name' => 'filter',
-				'label' => __( 'Automatically add paragraphs', 'default' ),
-				'type' => 'checkbox',
-			) );
-			?>
-		</script>
-		<?php
+	public function render_form_template() {
+		$this->render_title_form_field_template();
+		$this->render_form_field_template( array(
+			'name' => 'text',
+			'label' => __( 'Content:', 'default' ),
+			'type' => 'textarea',
+			'rows' => 16,
+			'cols' => 20,
+		) );
+		$this->render_form_field_template( array(
+			'name' => 'filter',
+			'label' => __( 'Automatically add paragraphs', 'default' ),
+			'type' => 'checkbox',
+		) );
 	}
 
 	/**

--- a/core-adapter-widgets/text/class.php
+++ b/core-adapter-widgets/text/class.php
@@ -25,7 +25,7 @@ class WP_JS_Widget_Text extends WP_Adapter_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'text' => array(
@@ -56,8 +56,8 @@ class WP_JS_Widget_Text extends WP_Adapter_JS_Widget {
 				),
 			)
 		);
-		$schema['title']['properties']['raw']['default'] = '';
-		return $schema;
+		$item_schema['title']['properties']['raw']['default'] = '';
+		return $item_schema;
 	}
 
 	/**

--- a/core-adapter-widgets/text/form.js
+++ b/core-adapter-widgets/text/form.js
@@ -15,8 +15,6 @@ wp.widgets.formConstructor.text = (function( api, $ ) {
 	 */
 	TextWidgetForm = wp.widgets.Form.extend({
 
-		id_base: 'text',
-
 		/**
 		 * Sanitize the instance data.
 		 *

--- a/core-adapter-widgets/text/form.js
+++ b/core-adapter-widgets/text/form.js
@@ -3,7 +3,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor.text = (function( api, $ ) {
+wp.widgets.formConstructor.text = (function( api, $ ) {
 	'use strict';
 
 	var TextWidgetForm;
@@ -13,18 +13,21 @@ wp.customize.Widgets.formConstructor.text = (function( api, $ ) {
 	 *
 	 * @constructor
 	 */
-	TextWidgetForm = api.Widgets.Form.extend({
+	TextWidgetForm = wp.widgets.Form.extend({
+
+		id_base: 'text',
 
 		/**
 		 * Sanitize the instance data.
 		 *
-		 * @param {object} oldInstance Unsanitized instance.
+		 * @param {object} newInstance Unsanitized instance.
+		 * @param {object} oldInstance Previous instance.
 		 * @returns {object} Sanitized instance.
 		 */
 		sanitize: function( newInstance, oldInstance ) {
 			var form = this, instance, code, notification;
 
-			instance = api.Widgets.Form.prototype.sanitize.call( form, newInstance, oldInstance );
+			instance = wp.widgets.Form.prototype.sanitize.call( form, newInstance, oldInstance );
 
 			if ( ! instance.text ) {
 				instance.text = '';
@@ -38,9 +41,9 @@ wp.customize.Widgets.formConstructor.text = (function( api, $ ) {
 						message: form.config.l10n.text_unfiltered_html_invalid,
 						type: 'warning'
 					} );
-					form.setting.notifications.add( code, notification );
+					form.notifications.add( code, notification );
 				} else {
-					form.setting.notifications.remove( code );
+					form.notifications.remove( code );
 				}
 			}
 

--- a/css/widget-form.css
+++ b/css/widget-form.css
@@ -1,0 +1,62 @@
+.js-widget-form-notifications-container {
+	margin: 4px 0 8px 0;
+	padding: 0;
+	display: none;
+	cursor: default;
+}
+
+.js-widget-form-notifications-container li.notice {
+	list-style: none;
+	margin: 0 0 6px 0;
+	padding: 4px 8px;
+}
+
+.js-widget-form-notifications-container li.notice:last-child {
+	margin-bottom: 0;
+}
+
+.js-widget-form-notifications-container .notice {
+	background: #fff;
+	border-left: 4px solid #fff;
+	-webkit-box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );
+	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );
+	margin: 5px 15px 2px;
+	padding: 1px 12px;
+}
+
+.js-widget-form-notifications-container .notice p {
+	margin: 0.5em 0;
+	padding: 2px;
+}
+
+.js-widget-form-notifications-container .notice-alt {
+	-webkit-box-shadow: none;
+	box-shadow: none;
+}
+.js-widget-form-notifications-container .notice-error {
+	border-left-color: #dc3232;
+}
+.js-widget-form-notifications-container .notice-error.notice-alt {
+	background-color: #fbeaea;
+}
+
+.js-widget-form-notifications-container .notice-info {
+	border-left-color: #00a0d2;
+}
+.js-widget-form-notifications-container .notice-info.notice-alt {
+	background-color: #e5f5fa;
+}
+
+.js-widget-form-notifications-container .notice-success{
+	border-left-color: #46b450;
+}
+.js-widget-form-notifications-container .notice-success.notice-alt {
+	background-color: #ecf7ed;
+}
+
+.js-widget-form-notifications-container .notice-warning {
+	border-left-color: #ffb900;
+}
+.js-widget-form-notifications-container .notice-warning.notice-alt {
+	background-color: #fff8e5;
+}

--- a/js-widgets.php
+++ b/js-widgets.php
@@ -3,7 +3,7 @@
  * Plugin Name: JS Widgets
  * Description: The next generation of widgets in core, embracing JS for UI and powering the Widgets REST API.
  * Plugin URI: https://github.com/xwp/wp-js-widgets/
- * Version: 0.2.0
+ * Version: 0.3.0-alpha
  * Author: Weston Ruter, XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/js-widgets.php
+++ b/js-widgets.php
@@ -3,7 +3,7 @@
  * Plugin Name: JS Widgets
  * Description: The next generation of widgets in core, embracing JS for UI and powering the Widgets REST API.
  * Plugin URI: https://github.com/xwp/wp-js-widgets/
- * Version: 0.3.0-alpha
+ * Version: 0.3.0
  * Author: Weston Ruter, XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/js/admin-js-widgets.js
+++ b/js/admin-js-widgets.js
@@ -7,7 +7,12 @@
 wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 	'use strict';
 
-	var component = {};
+	var component = {
+		l10n: {
+			save: '',
+			saved: ''
+		}
+	};
 
 	/**
 	 * Initialize component.
@@ -29,7 +34,7 @@ wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 	 * @returns {void}
 	 */
 	component.handleWidgetInitClick = function handleWidgetInitClick( event ) {
-		var widgetElement = $( event.currentTarget ), idBase, FormConstructor, form, instanceData, formContainer, widgetContentElement;
+		var widgetElement = $( event.currentTarget ), idBase, FormConstructor, form, instanceData, formContainer, widgetContentElement, saveBtn;
 		if ( ! widgetElement.hasClass( 'open' ) || widgetElement.data( 'js-widget-form' ) ) {
 			return;
 		}
@@ -50,8 +55,11 @@ wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 		} );
 		form.render();
 
+		saveBtn = widgetElement.find( '.widget-control-actions:last input[name=savewidget]' );
+
 		form.model.bind( function( newInstanceData ) {
 			widgetContentElement.find( '> input.js_widget_instance_data:first' ).val( JSON.stringify( newInstanceData ) );
+			saveBtn.prop( 'disabled', false ).val( component.l10n.save );
 		} );
 
 		widgetElement.find( '.widget-control-remove:last' ).on( 'click', function() {
@@ -61,6 +69,8 @@ wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 				widgetElement.removeData( 'js-widget-form' );
 			}, delay );
 		} );
+
+		saveBtn.prop( 'disabled', true ).val( component.l10n.saved );
 
 		widgetElement.data( 'js-widget-form', form );
 	};
@@ -73,7 +83,8 @@ wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 	 * @returns {void}
 	 */
 	component.handleWidgetUpdate = function handleWidgetUpdate( event, widgetElement ) {
-		var updatedInstanceData, updateNotificationsData, form = widgetElement.data( 'js-widget-form' ), instanceDataElement, errorCount = 0;
+		var updatedInstanceData, updateNotificationsData, form, instanceDataElement, errorCount, saveBtn;
+		form = widgetElement.data( 'js-widget-form' );
 		if ( ! form ) {
 			return;
 		}
@@ -92,6 +103,7 @@ wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 			}
 		} );
 
+		errorCount = 0;
 		_.each( updateNotificationsData, function( params, code ) {
 			var notification = new wp.customize.Notification( code, _.extend( { fromServer: true }, params ) );
 			form.notifications.add( code, notification );
@@ -105,6 +117,9 @@ wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
 		if ( 0 === errorCount ) {
 			updatedInstanceData = JSON.parse( instanceDataElement.val() );
 			widgetElement.data( 'js-widget-form' ).model.set( updatedInstanceData );
+			saveBtn = widgetElement.find( '.widget-control-actions:last input[name=savewidget]' );
+			saveBtn.prop( 'disabled', true );
+			saveBtn.val( component.l10n.saved );
 		} else {
 			instanceDataElement.val( JSON.stringify( widgetElement.data( 'js-widget-form' ).model.get() ) );
 		}

--- a/js/admin-js-widgets.js
+++ b/js/admin-js-widgets.js
@@ -1,0 +1,119 @@
+/* global wpWidgets, module, JSON */
+/* eslint-disable strict */
+/* eslint-disable complexity */
+/* eslint consistent-this: [ "error", "control" ] */
+/* eslint no-magic-numbers: [ "error", {"ignore":[0,1]} ] */
+
+wpWidgets.JSWidgets = (function( $ ) { // eslint-disable-line no-unused-vars
+	'use strict';
+
+	var component = {};
+
+	/**
+	 * Initialize component.
+	 *
+	 * @returns {void}
+	 */
+	component.init = function initComponent() {
+
+		component.handleWidgetInitClick = _.debounce( _.bind( component.handleWidgetInitClick, component ) );
+
+		$( document ).on( 'click.js-widgets-toggle', 'div.widget', component.handleWidgetInitClick );
+		$( document ).on( 'widget-updated', component.handleWidgetUpdate );
+	};
+
+	/**
+	 * Handle widget click to construct widget form.
+	 *
+	 * @param {jQuery.Event} event Event.
+	 * @returns {void}
+	 */
+	component.handleWidgetInitClick = function handleWidgetInitClick( event ) {
+		var widgetElement = $( event.currentTarget ), idBase, FormConstructor, form, instanceData, formContainer, widgetContentElement;
+		if ( ! widgetElement.hasClass( 'open' ) || widgetElement.data( 'js-widget-form' ) ) {
+			return;
+		}
+		idBase = widgetElement.find( '> .widget-inside > form:first > .id_base' ).val();
+		if ( ! wp.widgets.formConstructor[ idBase ] ) {
+			return;
+		}
+
+		widgetContentElement = widgetElement.find( '.widget-content:first' );
+		instanceData = JSON.parse( widgetContentElement.find( '> input.js_widget_instance_data:first' ).val() );
+		formContainer = $( '<div class="form-container">' );
+		widgetElement.find( '.widget-content:first' ).before( formContainer );
+
+		FormConstructor = wp.widgets.formConstructor[ idBase ];
+		form = new FormConstructor( {
+			container: formContainer,
+			model: new wp.customize.Value( instanceData )
+		} );
+		form.render();
+
+		form.model.bind( function( newInstanceData ) {
+			widgetContentElement.find( '> input.js_widget_instance_data:first' ).val( JSON.stringify( newInstanceData ) );
+		} );
+
+		widgetElement.find( '.widget-control-remove:last' ).on( 'click', function() {
+			var delay = 500;
+			setTimeout( function() {
+				form.destruct();
+				widgetElement.removeData( 'js-widget-form' );
+			}, delay );
+		} );
+
+		widgetElement.data( 'js-widget-form', form );
+	};
+
+	/**
+	 * Handle widget update to update form model and notifications.
+	 *
+	 * @param {jQuery.Event} event         Event.
+	 * @param {jQuery}       widgetElement Widget element.
+	 * @returns {void}
+	 */
+	component.handleWidgetUpdate = function handleWidgetUpdate( event, widgetElement ) {
+		var updatedInstanceData, updateNotificationsData, form = widgetElement.data( 'js-widget-form' ), instanceDataElement, errorCount = 0;
+		if ( ! form ) {
+			return;
+		}
+
+		updateNotificationsData = widgetElement.find( '.widget-content:first > .js_widget_notifications' ).val();
+		if ( updateNotificationsData ) {
+			updateNotificationsData = JSON.parse( updateNotificationsData );
+		} else {
+			updateNotificationsData = {};
+		}
+
+		// Remove notifications that are no longer present.
+		form.notifications.each( function( existingNotification ) {
+			if ( existingNotification.fromServer && ! updateNotificationsData[ existingNotification.code ] ) {
+				form.notifications.remove( existingNotification.code );
+			}
+		} );
+
+		_.each( updateNotificationsData, function( params, code ) {
+			var notification = new wp.customize.Notification( code, _.extend( { fromServer: true }, params ) );
+			form.notifications.add( code, notification );
+
+			if ( 'error' === notification.type ) {
+				errorCount += 1;
+			}
+		} );
+
+		instanceDataElement = widgetElement.find( 'input.js_widget_instance_data:first' );
+		if ( 0 === errorCount ) {
+			updatedInstanceData = JSON.parse( instanceDataElement.val() );
+			widgetElement.data( 'js-widget-form' ).model.set( updatedInstanceData );
+		} else {
+			instanceDataElement.val( JSON.stringify( widgetElement.data( 'js-widget-form' ).model.get() ) );
+		}
+	};
+
+	if ( 'undefined' !== typeof module ) {
+		module.exports = component;
+	}
+
+	return component;
+
+})( jQuery );

--- a/js/customize-js-widgets.js
+++ b/js/customize-js-widgets.js
@@ -144,6 +144,9 @@ wp.customize.JSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 			} );
 			options.params.widget_control = widgetControlWrapperMarkup;
 
+			// No-op renderNotifications in favor of letting Form handle it.
+			control.renderNotifications = function() {};
+
 			originalInitialize.call( control, id, options );
 		},
 

--- a/js/customize-js-widgets.js
+++ b/js/customize-js-widgets.js
@@ -1,31 +1,21 @@
 /* global wp, module */
-/* exported CustomizeJSWidgets */
 /* eslint-disable strict */
 /* eslint-disable complexity */
 /* eslint consistent-this: [ "error", "control" ] */
 
-var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-vars
+wp.customize.JSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-vars
 	'use strict';
 
-	var component, originalInitialize;
+	var component = {}, originalInitialize;
 
-	component = {
-		data: {
-			id_bases: {},
-			form_configs: {}
-		}
-	};
 	originalInitialize = api.Widgets.WidgetControl.prototype.initialize;
 
 	/**
 	 * Initialize component.
 	 *
-	 * @param {object} data
+	 * @returns {void}
 	 */
-	component.init = function initComponent( data ) {
-		if ( data ) {
-			_.extend( component.data, data );
-		}
+	component.init = function initComponent() {
 		component.extendWidgetControl();
 
 		// Handle (re-)adding a (previously-removed) control.
@@ -50,7 +40,7 @@ var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 	 * @returns {boolean} Whether the control is a JS widget.
 	 */
 	component.isJsWidgetControl = function isJsWidgetControl( widgetControl ) {
-		return widgetControl.extended( api.Widgets.WidgetControl ) && component.data.id_bases[ widgetControl.params.widget_id_base ];
+		return widgetControl.extended( api.Widgets.WidgetControl ) && 'undefined' !== typeof wp.widgets.formConstructor[ widgetControl.params.widget_id_base ];
 	};
 
 	/**
@@ -69,7 +59,7 @@ var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 		 */
 		api.Widgets.WidgetControl.prototype.initialize = function initializeWidgetControl( id, options ) {
 			var control = this, isJsWidget;
-			isJsWidget = options.params.widget_id_base && component.data.id_bases[ options.params.widget_id_base ];
+			isJsWidget = options.params.widget_id_base && 'undefined' !== typeof wp.widgets.formConstructor[ options.params.widget_id_base ];
 			if ( isJsWidget ) {
 				_.extend( control, component.WidgetControl.prototype );
 				component.WidgetControl.prototype.initialize.call( control, id, options );
@@ -178,9 +168,9 @@ var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 
 			// @todo This should actually set up the template and not wait until render. The container should be guaranteed.
 			control.form = new Form( {
-				control: control,
-				container: formContainer,
-				config: component.data.form_configs[ control.params.widget_id_base ]
+				model: control.setting,
+				id_base: control.params.widget_id_base,
+				container: formContainer
 			} );
 			control.form.render();
 
@@ -197,7 +187,7 @@ var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 		 * Handle changes to the setting.
 		 *
 		 * This mostly removes code located in `wp.customize.Widgets.WidgetControl.prototype._setupModel`,
-		 * as most of the code there is made obsolete by `wp.customize.Widgets.Form` which is responsible
+		 * as most of the code there is made obsolete by `wp.widgets.Form` which is responsible
 		 * for re-rendering the form when when the setting changes.
 		 *
 		 * @returns {void}
@@ -219,7 +209,7 @@ var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 		/**
 		 * Override WidgetControl logic for setting up event handlers for widget updating.
 		 *
-		 * This is now handled entirely in the wp.customize.Widgets.Form instance.
+		 * This is now handled entirely in the wp.widgets.Form instance.
 		 *
 		 * @returns {void}
 		 */
@@ -309,7 +299,9 @@ var CustomizeJSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 		}
 	});
 
-	api.Widgets.formConstructor = {};
+	api.Widgets.formConstructor = wp.widgets.formConstructor || {}; // @todo Eliminate the wp.widgets.formConstructor alias.
+	api.Widgets.Form = wp.widgets.Form; // @todo Eliminate alias.
+
 	if ( 'undefined' !== typeof module ) {
 		module.exports = component;
 	}

--- a/js/customize-js-widgets.js
+++ b/js/customize-js-widgets.js
@@ -172,7 +172,6 @@ wp.customize.JSWidgets = (function( api, $ ) { // eslint-disable-line no-unused-
 			// @todo This should actually set up the template and not wait until render. The container should be guaranteed.
 			control.form = new Form( {
 				model: control.setting,
-				id_base: control.params.widget_id_base,
 				container: formContainer
 			} );
 			control.form.render();

--- a/js/widget-form.js
+++ b/js/widget-form.js
@@ -180,7 +180,7 @@ wp.widgets.Form = (function( api, $ ) {
 		/**
 		 * Merge the props into the current value.
 		 *
-		 * @todo Rename this update? Rename this set? Or setExtend?
+		 * @todo Rename this update? Rename this set? Or setExtend? Or setValue()?
 		 *
 		 * @param {object} props Instance props.
 		 * @returns {void}
@@ -317,7 +317,7 @@ wp.widgets.Form = (function( api, $ ) {
 		 *
 		 * @returns {void}
 		 */
-		destruct: function destroy() {
+		destruct: function destruct() {
 			var form = this;
 			form.container.empty();
 			form.unlinkPropertyElements();

--- a/js/widget-form.js
+++ b/js/widget-form.js
@@ -21,13 +21,6 @@ wp.widgets.Form = (function( api, $ ) {
 	return api.Class.extend({
 
 		/**
-		 * ID base (type).
-		 *
-		 * @var string
-		 */
-		id_base: '',
-
-		/**
 		 * Form config.
 		 *
 		 * @var object
@@ -51,8 +44,8 @@ wp.widgets.Form = (function( api, $ ) {
 				{
 					model: null,
 					container: null,
-					id_base: form.id_base,
 					config: ! _.isEmpty( form.config ) ? _.clone( form.config ) : {
+						template_id: '',
 						l10n: {},
 						default_instance: {}
 					}
@@ -62,9 +55,6 @@ wp.widgets.Form = (function( api, $ ) {
 
 			if ( ! args.model || ! args.model.extended || ! args.model.extended( api.Value ) ) {
 				throw new Error( 'Missing model property which must be a Value or Setting instance.' );
-			}
-			if ( 'string' !== typeof args.id_base ) {
-				throw new Error( 'Missing id_base property.' );
 			}
 
 			_.extend( form, args );
@@ -288,7 +278,10 @@ wp.widgets.Form = (function( api, $ ) {
 		getTemplate: function getTemplate() {
 			var form = this;
 			if ( ! form._template ) {
-				form._template = wp.template( 'customize-widget-form-' + form.id_base );
+				if ( ! $( '#tmpl-' + form.config.template_id ).is( 'script[type="text/template"]' ) ) {
+					throw new Error( 'Missing script[type="text/template"]#' + form.config.template_id + ' script for widget form.' );
+				}
+				form._template = wp.template( form.config.template_id );
 			}
 			return form._template;
 		},

--- a/js/widget-form.js
+++ b/js/widget-form.js
@@ -51,7 +51,7 @@ wp.widgets.Form = (function( api, $ ) {
 						default_instance: {}
 					}
 				},
-				properties
+				properties ? _.clone( properties ) : {}
 			);
 
 			if ( ! args.model || ! args.model.extended || ! args.model.extended( api.Value ) ) {

--- a/js/widget-form.js
+++ b/js/widget-form.js
@@ -308,17 +308,17 @@ wp.widgets.Form = (function( api, $ ) {
 			var form = this, initialInstanceData;
 			initialInstanceData = form.getValue();
 			form.syncedProperties = {};
-			form.container.find( ':input[name]' ).each( function() {
-				var input = $( this ), name = input.prop( 'name' ), syncedProperty;
-				if ( _.isUndefined( initialInstanceData[ name ] ) ) {
+			form.container.find( ':input[data-field]' ).each( function() {
+				var input = $( this ), field = input.data( 'field' ), syncedProperty;
+				if ( _.isUndefined( initialInstanceData[ field ] ) ) {
 					return;
 				}
 
-				syncedProperty = form.createSyncedPropertyValue( form.model, name );
+				syncedProperty = form.createSyncedPropertyValue( form.model, field );
 				syncedProperty.element = new api.Element( input );
-				syncedProperty.element.set( initialInstanceData[ name ] );
+				syncedProperty.element.set( initialInstanceData[ field ] );
 				syncedProperty.element.sync( syncedProperty.value );
-				form.syncedProperties[ name ] = syncedProperty;
+				form.syncedProperties[ field ] = syncedProperty;
 			} );
 		},
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/xwp/wp-js-widgets.git"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "GPL-2.0+",
   "private": true,
   "devDependencies": {

--- a/php/class-js-widgets-plugin.php
+++ b/php/class-js-widgets-plugin.php
@@ -100,7 +100,7 @@ class JS_Widgets_Plugin {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
 		add_action( 'rest_api_init', array( $this, 'rest_api_init' ), 100 );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_pane_scripts' ) );
-		add_action( 'customize_controls_print_footer_scripts', array( $this, 'print_widget_form_templates' ) );
+		add_action( 'customize_controls_print_footer_scripts', array( $this, 'render_widget_form_template_scripts' ) );
 		add_action( 'customize_controls_init', array( $this, 'upgrade_customize_widget_controls' ) );
 		add_action( 'widgets_init', array( $this, 'capture_original_instances' ), 94 );
 		add_action( 'widgets_init', array( $this, 'upgrade_core_widgets' ) );
@@ -255,14 +255,14 @@ class JS_Widgets_Plugin {
 	/**
 	 * Print widget form templates.
 	 *
-	 * @see WP_Customize_Widget::form_template()
+	 * @see WP_Customize_Widget::render_form_template_scripts()
 	 */
-	function print_widget_form_templates() {
+	function render_widget_form_template_scripts() {
 		global $wp_widget_factory;
 
 		foreach ( $wp_widget_factory->widgets as $widget ) {
 			if ( $widget instanceof WP_JS_Widget ) {
-				$widget->form_template();
+				$widget->render_form_template_scripts();
 			}
 		}
 	}

--- a/php/class-js-widgets-plugin.php
+++ b/php/class-js-widgets-plugin.php
@@ -138,7 +138,7 @@ class JS_Widgets_Plugin {
 
 		$this->script_handles['form'] = 'js-widget-form';
 		$src = $plugin_dir_url . 'js/widget-form.js';
-		$deps = array( 'customize-base', 'wp-util', 'jquery' );
+		$deps = array( 'customize-base', 'wp-util', 'jquery', 'wp-a11y' );
 		$wp_scripts->add( $this->script_handles['form'], $src, $deps, $this->version );
 
 		$this->script_handles['customize-js-widgets'] = 'customize-js-widgets';
@@ -171,6 +171,11 @@ class JS_Widgets_Plugin {
 	 */
 	public function register_styles( WP_Styles $wp_styles ) {
 		global $wp_widget_factory;
+		$plugin_dir_url = plugin_dir_url( dirname( __FILE__ ) );
+
+		$src = $plugin_dir_url . 'css/widget-form.css';
+		$deps = array();
+		$wp_styles->add( 'js-widget-form', $src, $deps, $this->version );
 
 		// Register scripts for widgets.
 		foreach ( $wp_widget_factory->widgets as $widget ) {

--- a/php/class-js-widgets-plugin.php
+++ b/php/class-js-widgets-plugin.php
@@ -261,7 +261,11 @@ class JS_Widgets_Plugin {
 
 		$handle = 'admin-js-widgets';
 		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, 'wpWidgets.JSWidgets.init();' );
+		$l10n = array(
+			'save' => __( 'Save', 'default' ),
+			'saved' => __( 'Saved', 'default' ),
+		);
+		wp_add_inline_script( $handle, sprintf( 'wpWidgets.JSWidgets.l10n = %s; wpWidgets.JSWidgets.init();', wp_json_encode( $l10n ) ) );
 
 		foreach ( $wp_widget_factory->widgets as $widget ) {
 			if ( $widget instanceof WP_JS_Widget ) {

--- a/php/class-js-widgets-plugin.php
+++ b/php/class-js-widgets-plugin.php
@@ -136,15 +136,15 @@ class JS_Widgets_Plugin {
 		global $wp_widget_factory;
 		$plugin_dir_url = plugin_dir_url( dirname( __FILE__ ) );
 
-		$this->script_handles['control-form'] = 'customize-widget-control-form';
-		$src = $plugin_dir_url . 'js/customize-widget-control-form.js';
+		$this->script_handles['form'] = 'js-widget-form';
+		$src = $plugin_dir_url . 'js/widget-form.js';
 		$deps = array( 'customize-base', 'wp-util', 'jquery' );
-		$wp_scripts->add( $this->script_handles['control-form'], $src, $deps, $this->version );
+		$wp_scripts->add( $this->script_handles['form'], $src, $deps, $this->version );
 
-		$this->script_handles['js-widgets'] = 'customize-js-widgets';
+		$this->script_handles['customize-js-widgets'] = 'customize-js-widgets';
 		$src = $plugin_dir_url . 'js/customize-js-widgets.js';
-		$deps = array( 'customize-widgets', $this->script_handles['control-form'] );
-		$wp_scripts->add( $this->script_handles['js-widgets'], $src, $deps, $this->version );
+		$deps = array( $this->script_handles['form'] );
+		$wp_scripts->add( $this->script_handles['customize-js-widgets'], $src, $deps, $this->version );
 
 		$this->script_handles['trac-39389-controls'] = 'js-widgets-trac-39389-controls';
 		$src = $plugin_dir_url . 'js/trac-39389-controls.js';
@@ -214,27 +214,15 @@ class JS_Widgets_Plugin {
 
 		// Gather the id_bases (types) for JS Widgets and their form configs.
 		$customize_widget_id_bases = array();
-		$form_configs = array();
 		foreach ( $wp_widget_factory->widgets as $widget ) {
 			if ( $widget instanceof WP_JS_Widget ) {
 				$customize_widget_id_bases[ $widget->id_base ] = true;
-				$form_configs[ $widget->id_base ] = array_merge(
-					$widget->get_form_args(),
-					array(
-						'default_instance' => $widget->get_default_instance(),
-					)
-				);
 			}
 		}
 
-		$exports = array(
-			'id_bases' => $customize_widget_id_bases,
-			'form_configs' => $form_configs,
-		);
-
 		$handle = 'customize-js-widgets';
 		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, sprintf( 'CustomizeJSWidgets.init( %s );', wp_json_encode( $exports ) ) );
+		wp_add_inline_script( $handle, 'wp.customize.JSWidgets.init();' );
 
 		foreach ( $wp_widget_factory->widgets as $widget ) {
 			if ( $widget instanceof WP_JS_Widget ) {

--- a/php/class-js-widgets-rest-controller.php
+++ b/php/class-js-widgets-rest-controller.php
@@ -114,6 +114,7 @@ class JS_Widgets_REST_Controller extends WP_REST_Controller {
 
 			// Prevent clobbering reserved fields.
 			if ( in_array( $field_id, $reserved_field_ids, true ) ) {
+				/* translators: %s is field ID */
 				_doing_it_wrong( get_class( $this->widget ) . '::get_item_schema', sprintf( __( 'The field "%s" is reserved.', 'js-widgets' ), esc_html( $field_id ) ), '' ); // WPCS: xss ok.
 				continue;
 			}
@@ -271,7 +272,7 @@ class JS_Widgets_REST_Controller extends WP_REST_Controller {
 
 				$endpoint_args[ $field_id ] = array_merge( $endpoint_args[ $field_id ], $params['arg_options'] );
 			}
-		}
+		} // End foreach().
 
 		return $endpoint_args;
 	}
@@ -331,6 +332,7 @@ class JS_Widgets_REST_Controller extends WP_REST_Controller {
 				}
 			}
 			if ( ! $has_valid_type ) {
+				/* translators: 1 is param name, 2 is param types */
 				$error_messages = array( sprintf( __( 'Expected %1$s param to be of one types: %2$s', 'js-widgets' ), $param, join( ', ', $args['type'] ) ) );
 				foreach ( $errors as $sub_error ) {
 					foreach ( $sub_error->get_error_messages( 'rest_invalid_param' ) as $error_message ) {
@@ -345,6 +347,7 @@ class JS_Widgets_REST_Controller extends WP_REST_Controller {
 		// Validate object types.
 		if ( 'object' === $args['type'] ) {
 			if ( ! is_array( $value ) ) {
+				/* translators: %s is the type of the value */
 				return new WP_Error( 'rest_invalid_param', sprintf( __( 'Expected object but got %s.', 'js-widgets' ), gettype( $value ) ) );
 			}
 			if ( ! empty( $value ) && wp_is_numeric_array( $value ) ) {

--- a/php/class-js-widgets-rest-controller.php
+++ b/php/class-js-widgets-rest-controller.php
@@ -88,7 +88,7 @@ class JS_Widgets_REST_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema = array(
+		$item_schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->get_object_type(),
 			'type'       => 'object',
@@ -124,22 +124,22 @@ class JS_Widgets_REST_Controller extends WP_REST_Controller {
 				$field_schema['context'] = array( 'edit' );
 			}
 
-			$schema['properties'][ $field_id ] = $field_schema;
+			$item_schema['properties'][ $field_id ] = $field_schema;
 		}
 
-		$schema = $this->add_additional_fields_schema( $schema );
+		$item_schema = $this->add_additional_fields_schema( $item_schema );
 
 		// Expose root-level required properties according to JSON Schema.
-		if ( ! isset( $schema['required'] ) ) {
-			$schema['required'] = array();
+		if ( ! isset( $item_schema['required'] ) ) {
+			$item_schema['required'] = array();
 		}
-		foreach ( $schema['properties'] as $field_id => $field_schema ) {
+		foreach ( $item_schema['properties'] as $field_id => $field_schema ) {
 			if ( ! empty( $field_schema['required'] ) ) {
-				$schema['required'][] = $field_id;
+				$item_schema['required'][] = $field_id;
 			}
 		}
 
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/php/class-wp-adapter-js-widget.php
+++ b/php/class-wp-adapter-js-widget.php
@@ -85,7 +85,7 @@ abstract class WP_Adapter_JS_Widget extends WP_JS_Widget {
 		wp_add_inline_script( $handle, sprintf(
 			'wp.widgets.formConstructor[ %s ].prototype.config = %s;',
 			wp_json_encode( $this->id_base ),
-			wp_json_encode( $this->get_form_args() )
+			wp_json_encode( $this->get_form_config() )
 		) );
 	}
 

--- a/php/class-wp-adapter-js-widget.php
+++ b/php/class-wp-adapter-js-widget.php
@@ -67,9 +67,9 @@ abstract class WP_Adapter_JS_Widget extends WP_JS_Widget {
 	public function register_scripts( $wp_scripts ) {
 		$reflection_class = new ReflectionClass( get_class( $this ) );
 		$plugin_dir_url = plugin_dir_url( $reflection_class->getFileName() );
-		$handle = "customize-widget-form-{$this->id_base}";
+		$handle = "widget-form-{$this->id_base}";
 		$src = $plugin_dir_url . 'form.js';
-		$deps = array( $this->plugin->script_handles['control-form'] );
+		$deps = array( $this->plugin->script_handles['form'] );
 		$wp_scripts->add( $handle, $src, $deps, $this->plugin->version );
 	}
 
@@ -77,7 +77,18 @@ abstract class WP_Adapter_JS_Widget extends WP_JS_Widget {
 	 * Enqueue scripts needed for the control.s
 	 */
 	public function enqueue_control_scripts() {
-		wp_enqueue_script( "customize-widget-form-{$this->id_base}" );
+		parent::enqueue_control_scripts();
+
+		$handle = "widget-form-{$this->id_base}";
+		wp_enqueue_script( $handle );
+
+		$form_args = array_merge(
+			$this->get_form_args(),
+			array(
+				'default_instance' => $this->get_default_instance(),
+			)
+		);
+		wp_add_inline_script( $handle, sprintf( 'wp.widgets.formConstructor[ %s ].prototype.config = %s;', wp_json_encode( $this->id_base ), wp_json_encode( $form_args ) ) );
 	}
 
 	/**

--- a/php/class-wp-adapter-js-widget.php
+++ b/php/class-wp-adapter-js-widget.php
@@ -54,9 +54,9 @@ abstract class WP_Adapter_JS_Widget extends WP_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = parent::get_item_schema();
-		$schema['title']['properties']['raw']['default'] = $this->name;
-		return $schema;
+		$item_schema = parent::get_item_schema();
+		$item_schema['title']['properties']['raw']['default'] = $this->name;
+		return $item_schema;
 	}
 
 	/**

--- a/php/class-wp-adapter-js-widget.php
+++ b/php/class-wp-adapter-js-widget.php
@@ -82,13 +82,11 @@ abstract class WP_Adapter_JS_Widget extends WP_JS_Widget {
 		$handle = "widget-form-{$this->id_base}";
 		wp_enqueue_script( $handle );
 
-		$form_args = array_merge(
-			$this->get_form_args(),
-			array(
-				'default_instance' => $this->get_default_instance(),
-			)
-		);
-		wp_add_inline_script( $handle, sprintf( 'wp.widgets.formConstructor[ %s ].prototype.config = %s;', wp_json_encode( $this->id_base ), wp_json_encode( $form_args ) ) );
+		wp_add_inline_script( $handle, sprintf(
+			'wp.widgets.formConstructor[ %s ].prototype.config = %s;',
+			wp_json_encode( $this->id_base ),
+			wp_json_encode( $this->get_form_args() )
+		) );
 	}
 
 	/**

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -496,8 +496,6 @@ abstract class WP_JS_Widget extends WP_Widget {
 	/**
 	 * Render form field template.
 	 *
-	 * @todo Use a random string for a common name prefix to ensure that radio buttons will work properly.
-	 *
 	 * @param array $args Args.
 	 */
 	protected function render_form_field_template( $args = array() ) {
@@ -511,6 +509,13 @@ abstract class WP_JS_Widget extends WP_Widget {
 			'help' => '',
 			'class' => '',
 		);
+
+		if ( ! empty( $args['name'] ) ) {
+			_deprecated_argument( __FUNCTION__, '0.3.0', __( 'The args[name] param is deprecated in favor of args[field].', 'js-widgets' ) );
+		}
+		if ( empty( $args['field'] ) && ! empty( $args['name'] ) && ! empty( $item_schema[ $args['name'] ] ) ) {
+			$args['field'] = $args['name'];
+		}
 
 		$field_name = ! empty( $args['field'] ) ? $args['field'] : null;
 		if ( $field_name && ! empty( $item_schema[ $field_name ] ) ) {

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -625,16 +625,25 @@ abstract class WP_JS_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Get form args (config).
+	 *
+	 * @deprecated
+	 * @return array
+	 */
+	public function get_form_args() {
+		_deprecated_function( __FUNCTION__, '0.3.0', __CLASS__ . '::get_form_config()' );
+		return $this->get_form_config();
+	}
+
+	/**
 	 * Get data to pass to the JS form.
 	 *
 	 * This can include information such as whether the user can do `unfiltered_html`.
 	 * The `default_instance` will be amended to this when exported to JS.
 	 *
-	 * @todo Rename this to get_form_config?
-	 *
 	 * @return array
 	 */
-	public function get_form_args() {
+	public function get_form_config() {
 		return array(
 			'l10n' => array(
 				'title_tags_invalid' => __( 'Tags will be stripped from the title.', 'js-widgets' ),

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -525,21 +525,46 @@ abstract class WP_JS_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Render JS Template.
+	 * Get template ID for form.
+	 *
+	 * @return string Template ID.
 	 */
-	public function form_template() {
+	protected function get_form_template_id() {
+		return 'js-widget-form-' . $this->id_base;
+	}
+
+	/**
+	 * Render JS template.
+	 *
+	 * This method normally need not be overridden by a subclass, as it is just a
+	 * wrapper for `WP_JS_Widget::form_template_contents()`, which is the method
+	 * that subclasses should override.
+	 *
+	 * @see WP_JS_Widget::render_form_template()
+	 */
+	public function render_form_template_scripts() {
+		?>
+		<script id="tmpl-<?php echo esc_attr( $this->get_form_template_id() ) ?>" type="text/template">
+			<?php $this->render_form_template(); ?>
+		</script>
+		<?php
+	}
+
+	/**
+	 * Render contents of JS template.
+	 *
+	 * Note that the text/template script tag wrapper is output by `WP_JS_Widget::render_form_template_scripts()`.
+	 *
+	 * @see WP_JS_Widget::render_form_template_scripts()
+	 */
+	public function render_form_template() {
 		$placeholder = '';
 		if ( isset( $item_schema['title']['properties']['raw']['default'] ) ) {
 			$placeholder = $item_schema['title']['properties']['raw']['default'];
 		} elseif ( isset( $item_schema['title']['properties']['rendered']['default'] ) ) {
 			$placeholder = $item_schema['title']['properties']['rendered']['default'];
 		}
-
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php $this->render_title_form_field_template( compact( 'placeholder' ) ); ?>
-		</script>
-		<?php
+		$this->render_title_form_field_template( compact( 'placeholder' ) );
 	}
 
 	/**
@@ -555,11 +580,10 @@ abstract class WP_JS_Widget extends WP_Widget {
 	public function get_form_args() {
 		return array(
 			'l10n' => array(
-
-				// @todo Move this to the component level.
 				'title_tags_invalid' => __( 'Tags will be stripped from the title.', 'js-widgets' ),
 			),
 			'default_instance' => $this->get_default_instance(),
+			'template_id' => $this->get_form_template_id(),
 		);
 	}
 }

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -308,7 +308,10 @@ abstract class WP_JS_Widget extends WP_Widget {
 			?>
 			<input type="hidden" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ) ?>"  name="<?php echo esc_attr( $this->get_field_name( 'title' ) ) ?>" value="<?php echo esc_attr( isset( $instance['title'] ) ? $instance['title'] : '' ) ?>">
 			<p>
-				<?php echo sprintf( __( 'This widget can only be <a href="%s">edited in the Customizer</a>.', 'js-widgets' ), esc_url( $customize_url ) ); // WPCS: xss ok. ?>
+				<?php
+				/* translators: %s is the URL to the customizer. */
+				echo sprintf( __( 'This widget can only be <a href="%s">edited in the Customizer</a>.', 'js-widgets' ), esc_url( $customize_url ) ); // WPCS: xss ok.
+				?>
 			</p>
 			<?php
 			return 'noform';

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -102,7 +102,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array(
+		$item_schema = array(
 			'title' => array(
 				'description' => __( 'The title for the widget.', 'js-widgets' ),
 				'type' => array( 'string', 'object' ),
@@ -123,7 +123,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 				),
 			),
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -687,10 +687,9 @@ abstract class WP_JS_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Get data to pass to the JS form.
+	 * Get form config data to pass to the JS Form constructor.
 	 *
 	 * This can include information such as whether the user can do `unfiltered_html`.
-	 * The `default_instance` will be amended to this when exported to JS.
 	 *
 	 * @return array
 	 */

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -473,9 +473,8 @@ abstract class WP_JS_Widget extends WP_Widget {
 	protected function render_title_form_field_template( $input_attrs = array() ) {
 		$this->render_form_field_template( array_merge(
 			array(
-				'name' => 'title',
+				'field' => 'title',
 				'label' => __( 'Title:', 'default' ),
-				'type' => 'text',
 			),
 			$input_attrs
 		) );
@@ -502,22 +501,68 @@ abstract class WP_JS_Widget extends WP_Widget {
 	 * @param array $args Args.
 	 */
 	protected function render_form_field_template( $args = array() ) {
+		$item_schema = $this->get_item_schema();
 		$defaults = array(
-			'name' => '',
 			'label' => '',
 			'type' => 'text',
 			'choices' => array(),
 			'value' => '',
 			'placeholder' => '',
 			'help' => '',
+			'class' => '',
 		);
+
+		$field_name = ! empty( $args['field'] ) ? $args['field'] : null;
+		if ( $field_name && ! empty( $item_schema[ $field_name ] ) ) {
+			$field_schema = $item_schema[ $field_name ];
+			$schema_to_input_attrs_mapping = array(
+				'description' => 'label',
+				'minimum' => 'min',
+				'maximum' => 'max',
+				// @todo Use default as placeholder?
+			);
+			foreach ( $schema_to_input_attrs_mapping as $schema_key => $input_attr_key ) {
+				if ( isset( $field_schema[ $schema_key ] ) ) {
+					$defaults[ $input_attr_key ] = $field_schema[ $schema_key ];
+				}
+			}
+
+			if ( isset( $field_schema['type'] ) ) {
+				if ( 'boolean' === $field_schema['type'] ) {
+					$defaults['type'] = 'checkbox';
+				} elseif ( 'integer' === $field_schema['type'] || 'number' === $field_schema['type'] ) {
+					$defaults['type'] = 'number';
+				} elseif ( 'string' === $field_schema['type'] && isset( $field_schema['format'] ) ) {
+					if ( 'uri' === $field_schema['format'] ) {
+						$defaults['type'] = 'url';
+					} elseif ( 'email' === $field_schema['format'] ) {
+						$defaults['type'] = 'email';
+					}
+					// @todo Support date-time format.
+				}
+
+				if ( 'integer' === $field_schema['type'] ) {
+					$defaults['step'] = '1';
+				}
+			}
+
+			if ( isset( $field_schema['enum'] ) ) {
+				$defaults['choices'] = array_combine( $field_schema['enum'], $field_schema['enum'] );
+			}
+		} // End if().
+
 		if ( ! isset( $args['type'] ) || ( 'checkbox' !== $args['type'] && 'radio' !== $args['type'] ) ) {
-			$defaults['class'] = 'widefat';
+			$defaults['class'] .= ' widefat';
 		}
 		$args = wp_parse_args( $args, $defaults );
 
 		$input_attrs = $args;
-		unset( $input_attrs['label'], $input_attrs['choices'], $input_attrs['type'] );
+		unset( $input_attrs['label'], $input_attrs['choices'], $input_attrs['type'], $input_attrs['name'], $input_attrs['field'], $input_attrs['data-field'] );
+
+		if ( $field_name ) {
+			$input_attrs['data-field'] = $field_name;
+			$input_attrs['name'] = '{{ domId }}-' . $field_name;
+		}
 
 		echo '<p>';
 		echo '<# (function( domId ) { #>';
@@ -525,6 +570,12 @@ abstract class WP_JS_Widget extends WP_Widget {
 			?>
 			<input type="checkbox" id="{{ domId }}" <?php $this->render_input_attrs( $input_attrs ); ?> >
 			<label for="{{ domId }}"><?php echo esc_html( $args['label'] ); ?></label>
+			<?php
+		} elseif ( 'radio' === $args['type'] ) {
+			?>
+			<p>
+				<em><?php esc_html_e( 'Radio buttons are not supported yet.', 'js-widgets' ); ?></em>
+			</p>
 			<?php
 		} elseif ( 'select' === $args['type'] ) {
 			?>
@@ -556,7 +607,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 			<?php
 		}
 
-		echo '<# }( "el" + String( Math.random() ) )); #>';
+		echo '<# }( "el-" + String( Math.random() ) )); #>';
 		echo '</p>';
 	}
 

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -723,6 +723,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 	 * @see WP_JS_Widget::render_form_template_scripts()
 	 */
 	public function render_form_template() {
+		$item_schema = $this->get_item_schema();
 		$placeholder = '';
 		if ( isset( $item_schema['title']['properties']['raw']['default'] ) ) {
 			$placeholder = $item_schema['title']['properties']['raw']['default'];

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -559,6 +559,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 				// @todo Move this to the component level.
 				'title_tags_invalid' => __( 'Tags will be stripped from the title.', 'js-widgets' ),
 			),
+			'default_instance' => $this->get_default_instance(),
 		);
 	}
 }

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -85,7 +85,9 @@ abstract class WP_JS_Widget extends WP_Widget {
 	 *
 	 * A.K.A. enqueue_form_scripts, enqueue_backend_scripts.
 	 */
-	public function enqueue_control_scripts() {}
+	public function enqueue_control_scripts() {
+		wp_enqueue_style( 'js-widget-form' );
+	}
 
 	/**
 	 * Enqueue scripts needed for the frontend.
@@ -537,7 +539,14 @@ abstract class WP_JS_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Render JS template.
+	 * Whether form template scripts have been rendered.
+	 *
+	 * @var bool
+	 */
+	protected $form_template_scripts_rendered = false;
+
+	/**
+	 * Render form template scripts.
 	 *
 	 * This method normally need not be overridden by a subclass, as it is just a
 	 * wrapper for `WP_JS_Widget::form_template_contents()`, which is the method
@@ -546,8 +555,22 @@ abstract class WP_JS_Widget extends WP_Widget {
 	 * @see WP_JS_Widget::render_form_template()
 	 */
 	public function render_form_template_scripts() {
+		if ( $this->form_template_scripts_rendered ) {
+			return;
+		}
+		$this->form_template_scripts_rendered = true;
 		?>
+
+		<script id="tmpl-<?php echo esc_attr( $this->get_form_template_id() . '-notifications' ) ?>" type="text/template">
+			<ul>
+				<# _.each( data.notifications, function( notification ) { #>
+					<li class="notice notice-{{ notification.type || 'info' }} {{ data.altNotice ? 'notice-alt' : '' }}" data-code="{{ notification.code }}" data-type="{{ notification.type }}">{{{ notification.message || notification.code }}}</li>
+				<# } ); #>
+			</ul>
+		</script>
+
 		<script id="tmpl-<?php echo esc_attr( $this->get_form_template_id() ) ?>" type="text/template">
+			<div class="js-widget-form-notifications-container customize-control-notifications-container"></div>
 			<?php $this->render_form_template(); ?>
 		</script>
 		<?php
@@ -586,7 +609,8 @@ abstract class WP_JS_Widget extends WP_Widget {
 				'title_tags_invalid' => __( 'Tags will be stripped from the title.', 'js-widgets' ),
 			),
 			'default_instance' => $this->get_default_instance(),
-			'template_id' => $this->get_form_template_id(),
+			'form_template_id' => $this->get_form_template_id(),
+			'notifications_template_id' => $this->get_form_template_id() . '-notifications',
 		);
 	}
 }

--- a/php/class-wp-js-widget.php
+++ b/php/class-wp-js-widget.php
@@ -494,13 +494,59 @@ abstract class WP_JS_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Attributes that are recognized for input, select, and textarea elements.
+	 *
+	 * @var array
+	 */
+	protected $form_field_html_attribute_whitelist = array(
+		'accept',
+		'accesskey',
+		'accesskey',
+		'autocapitalize',
+		'autocomplete',
+		'autocorrect',
+		'autofocus',
+		'checked',
+		'class',
+		'cols',
+		'dir',
+		'disabled',
+		'height',
+		'incremental',
+		'inputmode',
+		'lang',
+		'list',
+		'max',
+		'maxlength',
+		'min',
+		'minlength',
+		'multiple',
+		'name',
+		'pattern',
+		'placeholder',
+		'readonly',
+		'required',
+		'results',
+		'rows',
+		'size',
+		'spellcheck',
+		'step',
+		'style',
+		'tabindex',
+		'title',
+		'type',
+		'width',
+		'wrap',
+	);
+
+	/**
 	 * Render form field template.
 	 *
 	 * @param array $args Args.
 	 */
 	protected function render_form_field_template( $args = array() ) {
 		$item_schema = $this->get_item_schema();
-		$defaults = array(
+		$default_input_attrs = array(
 			'label' => '',
 			'type' => 'text',
 			'choices' => array(),
@@ -512,9 +558,10 @@ abstract class WP_JS_Widget extends WP_Widget {
 
 		if ( ! empty( $args['name'] ) ) {
 			_deprecated_argument( __FUNCTION__, '0.3.0', __( 'The args[name] param is deprecated in favor of args[field].', 'js-widgets' ) );
-		}
-		if ( empty( $args['field'] ) && ! empty( $args['name'] ) && ! empty( $item_schema[ $args['name'] ] ) ) {
-			$args['field'] = $args['name'];
+
+			if ( empty( $args['field'] ) && ! empty( $item_schema[ $args['name'] ] ) ) {
+				$args['field'] = $args['name'];
+			}
 		}
 
 		$field_name = ! empty( $args['field'] ) ? $args['field'] : null;
@@ -528,41 +575,46 @@ abstract class WP_JS_Widget extends WP_Widget {
 			);
 			foreach ( $schema_to_input_attrs_mapping as $schema_key => $input_attr_key ) {
 				if ( isset( $field_schema[ $schema_key ] ) ) {
-					$defaults[ $input_attr_key ] = $field_schema[ $schema_key ];
+					$default_input_attrs[ $input_attr_key ] = $field_schema[ $schema_key ];
 				}
 			}
 
 			if ( isset( $field_schema['type'] ) ) {
-				if ( 'boolean' === $field_schema['type'] ) {
-					$defaults['type'] = 'checkbox';
-				} elseif ( 'integer' === $field_schema['type'] || 'number' === $field_schema['type'] ) {
-					$defaults['type'] = 'number';
-				} elseif ( 'string' === $field_schema['type'] && isset( $field_schema['format'] ) ) {
+				$schema_type = $field_schema['type'];
+
+				if ( 'boolean' === $schema_type ) {
+					$default_input_attrs['type'] = 'checkbox';
+				} elseif ( 'integer' === $schema_type || 'number' === $schema_type ) {
+					$default_input_attrs['type'] = 'number';
+				} elseif ( 'string' === $schema_type && isset( $field_schema['format'] ) ) {
 					if ( 'uri' === $field_schema['format'] ) {
-						$defaults['type'] = 'url';
+						$default_input_attrs['type'] = 'url';
 					} elseif ( 'email' === $field_schema['format'] ) {
-						$defaults['type'] = 'email';
+						$default_input_attrs['type'] = 'email';
 					}
 					// @todo Support date-time format.
 				}
 
-				if ( 'integer' === $field_schema['type'] ) {
-					$defaults['step'] = '1';
+				if ( 'integer' === $schema_type ) {
+					$default_input_attrs['step'] = '1';
 				}
 			}
 
 			if ( isset( $field_schema['enum'] ) ) {
-				$defaults['choices'] = array_combine( $field_schema['enum'], $field_schema['enum'] );
+				$default_input_attrs['choices'] = array_combine( $field_schema['enum'], $field_schema['enum'] );
 			}
 		} // End if().
 
 		if ( ! isset( $args['type'] ) || ( 'checkbox' !== $args['type'] && 'radio' !== $args['type'] ) ) {
-			$defaults['class'] .= ' widefat';
+			$default_input_attrs['class'] .= ' widefat';
 		}
-		$args = wp_parse_args( $args, $defaults );
-
-		$input_attrs = $args;
-		unset( $input_attrs['label'], $input_attrs['choices'], $input_attrs['type'], $input_attrs['name'], $input_attrs['field'], $input_attrs['data-field'] );
+		$args = wp_parse_args( $args, $default_input_attrs );
+		$input_attrs = array();
+		foreach ( $args as $arg_name => $arg_value ) {
+			if ( 'data-' === substr( $arg_name, 0, 5 ) || in_array( $arg_name, $this->form_field_html_attribute_whitelist, true ) ) {
+				$input_attrs[ $arg_name ] = $arg_value;
+			}
+		}
 
 		if ( $field_name ) {
 			$input_attrs['data-field'] = $field_name;
@@ -571,18 +623,18 @@ abstract class WP_JS_Widget extends WP_Widget {
 
 		echo '<p>';
 		echo '<# (function( domId ) { #>';
-		if ( 'checkbox' === $args['type'] ) {
+		if ( 'checkbox' === $input_attrs['type'] ) {
 			?>
 			<input type="checkbox" id="{{ domId }}" <?php $this->render_input_attrs( $input_attrs ); ?> >
 			<label for="{{ domId }}"><?php echo esc_html( $args['label'] ); ?></label>
 			<?php
-		} elseif ( 'radio' === $args['type'] ) {
+		} elseif ( 'radio' === $input_attrs['type'] ) {
 			?>
 			<p>
 				<em><?php esc_html_e( 'Radio buttons are not supported yet.', 'js-widgets' ); ?></em>
 			</p>
 			<?php
-		} elseif ( 'select' === $args['type'] ) {
+		} elseif ( 'select' === $input_attrs['type'] ) {
 			?>
 			<label for="{{ domId }}"> <?php echo esc_html( $args['label'] ); ?></label>
 			<select id="{{ domId }}" <?php $this->render_input_attrs( $input_attrs ); ?> >
@@ -593,7 +645,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 				<?php endforeach; ?>
 			</select>
 			<?php
-		} elseif ( 'textarea' === $args['type'] ) {
+		} elseif ( 'textarea' === $input_attrs['type'] ) {
 			?>
 			<label for="{{ domId }}"><?php echo esc_html( $args['label'] ); ?></label>
 			<textarea id="{{ domId }}" <?php $this->render_input_attrs( $input_attrs ); ?> ></textarea>
@@ -601,7 +653,7 @@ abstract class WP_JS_Widget extends WP_Widget {
 		} else {
 			?>
 			<label for="{{ domId }}"><?php echo esc_html( $args['label'] ); ?></label>
-			<input type="<?php echo esc_attr( $args['type'] ) ?>" id="{{ domId }}" <?php $this->render_input_attrs( $input_attrs ); ?> >
+			<input type="<?php echo esc_attr( $input_attrs['type'] ) ?>" id="{{ domId }}" <?php $this->render_input_attrs( $input_attrs ); ?> >
 			<?php
 		} // End if().
 

--- a/post-collection-widget.php
+++ b/post-collection-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: JS Widgets: Post Collection Widget
  * Description: A widget allowing for featuring a curated list of posts.
  * Plugin URI: https://github.com/xwp/wp-js-widgets/
- * Version: 0.2.0
+ * Version: 0.3.0-alpha
  * Author: Weston Ruter, XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -98,6 +98,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	 * Enqueue scripts needed for the controls.
 	 */
 	public function enqueue_control_scripts() {
+		parent::enqueue_control_scripts();
 
 		// Gracefully handle the customize-object-selector plugin not being active.
 		$handle = 'customize-widget-form-post-collection';

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -304,6 +304,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 							<address class="author">
 								<?php
 								echo sprintf(
+									/* translators: %s is the author display name */
 									esc_html__( 'By %s', 'js-widgets' ),
 									esc_html( get_the_author_meta( 'display_name', $query->post->post_author ) )
 								);
@@ -351,6 +352,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 				<p><em>
 					<?php
 					echo wp_kses_post( sprintf(
+						/* translators: %s is the link to the Customize Object Selector plugin */
 						__( 'This widget depends on the %s plugin. Please install and activate.', 'js-widgets' ),
 						sprintf(
 							'<a target="_blank" href="%1$s">%2$s</a>',

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -420,19 +420,16 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 			</p>
 			<?php
 			$this->render_form_field_template( array(
-				'name' => 'show_date',
+				'field' => 'show_date',
 				'label' => __( 'Show date', 'js-widgets' ),
-				'type' => 'checkbox',
 			) );
 			$this->render_form_field_template( array(
-				'name' => 'show_author',
+				'field' => 'show_author',
 				'label' => __( 'Show author', 'js-widgets' ),
-				'type' => 'checkbox',
 			) );
 			$this->render_form_field_template( array(
-				'name' => 'show_featured_image',
+				'field' => 'show_featured_image',
 				'label' => __( 'Show featured image', 'js-widgets' ),
-				'type' => 'checkbox',
 			) );
 			?>
 		<?php endif;

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -149,7 +149,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	 * @return array Schema.
 	 */
 	public function get_item_schema() {
-		$schema = array_merge(
+		$item_schema = array_merge(
 			parent::get_item_schema(),
 			array(
 				'show_date' => array(
@@ -190,7 +190,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 				),
 			)
 		);
-		return $schema;
+		return $item_schema;
 	}
 
 	/**

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -71,7 +71,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 		$plugin_dir_url = plugin_dir_url( __FILE__ );
 		$handle = 'customize-widget-form-post-collection';
 		$src = $plugin_dir_url . 'form.js';
-		$deps = array( 'customize-js-widgets' );
+		$deps = array( 'js-widget-form' );
 		$wp_scripts->add( $handle, $src, $deps, $this->plugin->version );
 	}
 

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -344,7 +344,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	 *
 	 * This template is intended to be agnostic to the JS template technology used.
 	 */
-	public function form_template() {
+	public function render_form_template_scripts() {
 		?>
 		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
 			<?php if ( ! wp_scripts()->query( 'customize-object-selector-component' ) ) : ?>

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -126,7 +126,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 		wp_add_inline_script( $handle, sprintf(
 			'wp.widgets.formConstructor[ %s ].prototype.config = %s;',
 			wp_json_encode( $this->id_base ),
-			wp_json_encode( $this->get_form_args() )
+			wp_json_encode( $this->get_form_config() )
 		) );
 
 		$handle = 'customize-widget-form-post-collection';
@@ -356,9 +356,9 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	 *
 	 * @return array
 	 */
-	public function get_form_args() {
+	public function get_form_config() {
 		return array_merge(
-			parent::get_form_args(),
+			parent::get_form_config(),
 			array(
 				'post_query_args' => $this->post_query_vars,
 				'select2_options' => $this->select2_options,

--- a/post-collection-widget/class-widget.php
+++ b/post-collection-widget/class-widget.php
@@ -63,6 +63,21 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	}
 
 	/**
+	 * Get Customize Object Selector Plugin.
+	 *
+	 * @global \CustomizeObjectSelector\Plugin $customize_object_selector_plugin
+	 * @return \CustomizeObjectSelector\Plugin|null Plugin or null if not active.
+	 */
+	public function get_customize_object_selector_plugin() {
+		global $customize_object_selector_plugin;
+		if ( ! empty( $customize_object_selector_plugin ) && 'CustomizeObjectSelector\Plugin' === get_class( $customize_object_selector_plugin ) ) {
+			return $customize_object_selector_plugin;
+		} else {
+			return null;
+		}
+	}
+
+	/**
 	 * Register scripts.
 	 *
 	 * @param WP_Scripts $wp_scripts Scripts.
@@ -100,15 +115,25 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	public function enqueue_control_scripts() {
 		parent::enqueue_control_scripts();
 
+		$has_customize_object_selector_plugin = ! is_null( $this->get_customize_object_selector_plugin() );
+
 		// Gracefully handle the customize-object-selector plugin not being active.
 		$handle = 'customize-widget-form-post-collection';
-		$external_dep_handle = 'customize-object-selector-component';
-		if ( wp_scripts()->query( $external_dep_handle ) ) {
-			wp_scripts()->query( $handle )->deps[] = $external_dep_handle;
+		if ( $has_customize_object_selector_plugin ) {
+			wp_scripts()->query( $handle )->deps[] = 'customize-object-selector-component';
 		}
 		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, sprintf(
+			'wp.widgets.formConstructor[ %s ].prototype.config = %s;',
+			wp_json_encode( $this->id_base ),
+			wp_json_encode( $this->get_form_args() )
+		) );
 
-		wp_enqueue_style( 'customize-widget-form-post-collection' );
+		$handle = 'customize-widget-form-post-collection';
+		wp_enqueue_style( $handle );
+		if ( $has_customize_object_selector_plugin ) {
+			wp_styles()->query( $handle )->deps[] = 'customize-object-selector';
+		}
 	}
 
 	/**
@@ -259,7 +284,7 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 		}
 
 		if ( empty( $instance['title'] ) ) {
-			$instance['title'] = __( 'Post Collection', 'js-widgets' );
+			$instance['title'] = $this->name;
 		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
@@ -332,65 +357,24 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 	 * @return array
 	 */
 	public function get_form_args() {
-		return array(
-			'l10n' => array(
-				'title_tags_invalid' => __( 'Tags will be stripped from the title.', 'js-widgets' ),
-			),
-			'post_query_args' => $this->post_query_vars,
-			'select2_options' => $this->select2_options,
+		return array_merge(
+			parent::get_form_args(),
+			array(
+				'post_query_args' => $this->post_query_vars,
+				'select2_options' => $this->select2_options,
+			)
 		);
 	}
 
 	/**
-	 * Render JS Template.
+	 * Render form template scripts.
 	 *
-	 * This template is intended to be agnostic to the JS template technology used.
+	 * @inheritdoc
 	 */
 	public function render_form_template_scripts() {
-		?>
-		<script id="tmpl-customize-widget-form-<?php echo esc_attr( $this->id_base ) ?>" type="text/template">
-			<?php if ( ! wp_scripts()->query( 'customize-object-selector-component' ) ) : ?>
-				<p><em>
-					<?php
-					echo wp_kses_post( sprintf(
-						/* translators: %s is the link to the Customize Object Selector plugin */
-						__( 'This widget depends on the %s plugin. Please install and activate.', 'js-widgets' ),
-						sprintf(
-							'<a target="_blank" href="%1$s">%2$s</a>',
-							'https://github.com/xwp/wp-customize-object-selector',
-							__( 'Customize Object Selector', 'js-widgets' )
-						)
-					) );
-					?>
-				</em></p>
-			<?php else : ?>
-				<?php
-				$this->render_title_form_field_template();
-				?>
-				<p class="posts-selector">
-					<label for="{{ data.config.select_id }}"><?php esc_html_e( 'Posts:', 'js-widgets' ) ?></label>
-					<span class="customize-object-selector-container"></span>
-				</p>
-				<?php
-				$this->render_form_field_template( array(
-					'name' => 'show_date',
-					'label' => __( 'Show date', 'js-widgets' ),
-					'type' => 'checkbox',
-				) );
-				$this->render_form_field_template( array(
-					'name' => 'show_author',
-					'label' => __( 'Show author', 'js-widgets' ),
-					'type' => 'checkbox',
-				) );
-				$this->render_form_field_template( array(
-					'name' => 'show_featured_image',
-					'label' => __( 'Show featured image', 'js-widgets' ),
-					'type' => 'checkbox',
-				) );
-				?>
-			<?php endif; ?>
-		</script>
+		parent::render_form_template_scripts();
 
+		?>
 		<script id="tmpl-customize-widget-post-collection-select2-option" type="text/template">
 			<# if ( data.featured_image && data.featured_image.sizes && data.featured_image.sizes.thumbnail && data.featured_image.sizes.thumbnail.url ) { #>
 				<span class="select2-thumbnail-wrapper">
@@ -402,5 +386,55 @@ class WP_JS_Widget_Post_Collection extends WP_JS_Widget {
 			<# } #>
 		</script>
 		<?php
+	}
+
+	/**
+	 * Render JS template contents minus the `<script type="text/template">` wrapper.
+	 *
+	 * This is called in `WP_JS_Widget::render_form_template_scripts()`.
+	 *
+	 * @see WP_JS_Widget::render_form_template_scripts()
+	 */
+	public function render_form_template() {
+		if ( ! wp_script_is( 'customize-object-selector-component' ) ) : ?>
+			<p><em>
+				<?php
+				echo wp_kses_post( sprintf(
+					/* translators: %s is the link to the Customize Object Selector plugin */
+					__( 'This widget depends on the %s plugin. Please install and activate.', 'js-widgets' ),
+					sprintf(
+						'<a target="_blank" href="%1$s">%2$s</a>',
+						'https://github.com/xwp/wp-customize-object-selector',
+						__( 'Customize Object Selector', 'js-widgets' )
+					)
+				) );
+				?>
+			</em></p>
+		<?php else : ?>
+			<?php
+			$this->render_title_form_field_template();
+			?>
+			<p class="posts-selector">
+				<label for="{{ data.config.select_id }}"><?php esc_html_e( 'Posts:', 'js-widgets' ) ?></label>
+				<span class="customize-object-selector-container"></span>
+			</p>
+			<?php
+			$this->render_form_field_template( array(
+				'name' => 'show_date',
+				'label' => __( 'Show date', 'js-widgets' ),
+				'type' => 'checkbox',
+			) );
+			$this->render_form_field_template( array(
+				'name' => 'show_author',
+				'label' => __( 'Show author', 'js-widgets' ),
+				'type' => 'checkbox',
+			) );
+			$this->render_form_field_template( array(
+				'name' => 'show_featured_image',
+				'label' => __( 'Show featured image', 'js-widgets' ),
+				'type' => 'checkbox',
+			) );
+			?>
+		<?php endif;
 	}
 }

--- a/post-collection-widget/form.js
+++ b/post-collection-widget/form.js
@@ -4,7 +4,7 @@
 /* eslint-disable strict */
 /* eslint-disable complexity */
 
-wp.customize.Widgets.formConstructor['post-collection'] = (function( api ) {
+wp.widgets.formConstructor['post-collection'] = (function( api ) {
 	'use strict';
 
 	var PostCollectionWidgetForm;
@@ -14,7 +14,9 @@ wp.customize.Widgets.formConstructor['post-collection'] = (function( api ) {
 	 *
 	 * @constructor
 	 */
-	PostCollectionWidgetForm = api.Widgets.Form.extend({
+	PostCollectionWidgetForm = wp.widgets.Form.extend({
+
+		id_base: 'post-collection',
 
 		/**
 		 * Initialize.
@@ -31,7 +33,7 @@ wp.customize.Widgets.formConstructor['post-collection'] = (function( api ) {
 			props.config = _.clone( props.config );
 			props.config.select_id = 'select' + String( Math.random() );
 
-			api.Widgets.Form.prototype.initialize.call( form, props );
+			wp.widgets.Form.prototype.initialize.call( form, props );
 		},
 
 		/**
@@ -42,7 +44,7 @@ wp.customize.Widgets.formConstructor['post-collection'] = (function( api ) {
 		 */
 		render: function render() {
 			var form = this, selectorContainer;
-			api.Widgets.Form.prototype.render.call( form );
+			wp.widgets.Form.prototype.render.call( form );
 
 			if ( api.ObjectSelectorComponent ) {
 
@@ -78,7 +80,7 @@ wp.customize.Widgets.formConstructor['post-collection'] = (function( api ) {
 		linkPropertyElements: function linkPropertyElements() {
 			var form = this;
 
-			api.Widgets.Form.prototype.linkPropertyElements.call( form );
+			wp.widgets.Form.prototype.linkPropertyElements.call( form );
 			if ( api.ObjectSelectorComponent ) {
 				form.syncedProperties.posts = form.createSyncedPropertyValue( form.setting, 'posts' );
 			}

--- a/post-collection-widget/form.js
+++ b/post-collection-widget/form.js
@@ -16,24 +16,17 @@ wp.widgets.formConstructor['post-collection'] = (function( api ) {
 	 */
 	PostCollectionWidgetForm = wp.widgets.Form.extend({
 
-		id_base: 'post-collection',
-
 		/**
 		 * Initialize.
 		 *
-		 * @param {object}                             properties         Properties.
-		 * @param {wp.customize.Widgets.WidgetControl} properties.control Customize control.
-		 * @param {object}                             properties.config  Form config.
+		 * @param {object} properties         Properties.
+		 * @param {object} properties.config  Form config.
 		 * @return {void}
 		 */
 		initialize: function initializePostCollectionWidgetForm( properties ) {
-			var form = this, props;
-
-			props = _.clone( properties );
-			props.config = _.clone( props.config );
-			props.config.select_id = 'select' + String( Math.random() );
-
-			wp.widgets.Form.prototype.initialize.call( form, props );
+			var form = this;
+			wp.widgets.Form.prototype.initialize.call( form, properties );
+			form.config.select_id = 'select' + String( Math.random() );
 		},
 
 		/**
@@ -54,7 +47,7 @@ wp.widgets.formConstructor['post-collection'] = (function( api ) {
 
 				form.postObjectSelector = new api.ObjectSelectorComponent({
 					model: form.syncedProperties.posts.value,
-					containing_construct: form.control,
+					containing_construct: form,
 					post_query_vars: form.config.post_query_args,
 					select2_options: _.extend(
 						{

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,26 @@ Limitations/Caveats:
 
 ## Changelog ##
 
+### 0.3.0 - 2017-01-?? (Unreleased) ###
+* *Remove forms dependency on customize-widgets; allow standalone forms to allow for Shortcake or frontend integrations* (PR [#26](https://github.com/xwp/wp-js-widgets/pull/26))
+* Remove forms dependency on `customize-widgets.js` to allow standalone forms to allow for Shortcake or frontend integrations.
+* Remove the passing of the `WidgetControl` as a property when constructing a Form; instead pass the model
+  (which can be a Setting or a Value) and id_base directly, the latter of which should already be located
+  on the Form prototype along with the config.
+* Replace `wp.customize.Widgets.formConstructor` with `wp.widgets.formConstructor`
+* Replace `wp.customize.Widgets.Form` with `wp.widgets.Form`
+* Eliminate exporting all form configs to CustomizeJSWidgets.data.form_configs and instead attach to From prototypes.
+* Fix initialization of Pages widget in how it amends the default config.
+* Add Form.notifications
+* Rename script handles to be more appropriate.
+* Fix PHP warning for array to string conversion in Pages widget.
+* Prevent RSS widget from showing error when feed URL is empty.
+* Reduce duplicated code for rendering form templates.
+* *Breaking change:* Converts/renames WP_JS_Widget::form_template() into wrapper method `WP_JS_Widget::render_form_template_scripts()` which outputs the script tags.
+* Splits out form template contents into `WP_JS_Widget::render_form_template()`.
+* Eliminates extraneous `id_base` property for JS Form class, adding `template_id` form config which is then sourced from a new `WP_JS_Widget::get_form_template_id()`, which in turn is used by `WP_JS_Widget::render_form_template_scripts()` and is used in the JS `Form#getTemplate` method.
+* Ensure that notifications for the setting (model) render even when the form is embedded outside the customizer.
+
 ### 0.2.0 - 2017-01-02 ###
 * Important: Update minimum WordPress core version to 4.7.0.
 * Eliminate `Form#embed` JS method in favor of just `Form#render`. Introduce `Form#destruct` to handle unmounting a rendered form.

--- a/readme.md
+++ b/readme.md
@@ -50,13 +50,13 @@ Limitations/Caveats:
 
 ## Changelog ##
 
-### 0.3.0 - 2017-01-09 ###
+### 0.3.0 - 2017-01-11 ###
 Added:
 
 * Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (see [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
 * Render widget forms on widgets admin screen instead of directing the widgets to be edited in the customizer. PR [#27](https://github.com/xwp/wp-js-widgets/pull/27).
 * Improve UX of Save button on for a widget on the widgets admin screen to show as disabled and “Saved” if setting is not dirty. See [wpcore#23120](https://core.trac.wordpress.org/ticket/23120#comment:46) (There should be indication that widget settings have been saved).
-* Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28).
+* Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28) and [#31](https://github.com/xwp/wp-js-widgets/pull/31).
 * Add `Form.notifications`, copying from `props.model.notifications` if it exists.
 
 Changed (*Breaking!*):

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Limitations/Caveats:
 ### 0.3.0 - 2017-01-09 ###
 Added:
 
-* Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (See [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
+* Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (see [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
 * Render widget forms on widgets admin screen instead of directing the widgets to be edited in the customizer. PR [#27](https://github.com/xwp/wp-js-widgets/pull/27).
 * Improve UX of Save button on for a widget on the widgets admin screen to show as disabled and “Saved” if setting is not dirty. See [wpcore#23120](https://core.trac.wordpress.org/ticket/23120#comment:46) (There should be indication that widget settings have been saved).
 * Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28).

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ The next generation of widgets in core, embracing JS for UI and powering the Wid
 **Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [widgets](https://wordpress.org/plugins/tags/widgets), [rest-api](https://wordpress.org/plugins/tags/rest-api)  
 **Requires at least:** 4.7.0  
 **Tested up to:** 4.7.0  
-**Stable tag:** 0.2.0  
+**Stable tag:** 0.3.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
 [![Build Status](https://travis-ci.org/xwp/wp-js-widgets.svg?branch=master)](https://travis-ci.org/xwp/wp-js-widgets) [![Coverage Status](https://coveralls.io/repos/xwp/wp-js-widgets/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-js-widgets) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-js-widgets/dev-status.svg)](https://david-dm.org/xwp/wp-js-widgets#info=devDependencies) 
@@ -50,25 +50,38 @@ Limitations/Caveats:
 
 ## Changelog ##
 
-### 0.3.0 - 2017-01-?? (Unreleased) ###
-* *Remove forms dependency on customize-widgets; allow standalone forms to allow for Shortcake or frontend integrations* (PR [#26](https://github.com/xwp/wp-js-widgets/pull/26))
-* Remove forms dependency on `customize-widgets.js` to allow standalone forms to allow for Shortcake or frontend integrations.
-* Remove the passing of the `WidgetControl` as a property when constructing a Form; instead pass the model
-  (which can be a Setting or a Value) and id_base directly, the latter of which should already be located
-  on the Form prototype along with the config.
-* Replace `wp.customize.Widgets.formConstructor` with `wp.widgets.formConstructor`
-* Replace `wp.customize.Widgets.Form` with `wp.widgets.Form`
-* Eliminate exporting all form configs to CustomizeJSWidgets.data.form_configs and instead attach to From prototypes.
-* Fix initialization of Pages widget in how it amends the default config.
-* Add Form.notifications
+### 0.3.0 - 2017-01-09 ###
+Added:
+
+* Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (See [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
+* Render widget forms on widgets admin screen instead of directing the widgets to be edited in the customizer. PR [#27](https://github.com/xwp/wp-js-widgets/pull/27).
+* Improve UX of Save button on for a widget on the widgets admin screen to show as disabled and “Saved” if setting is not dirty. See [wpcore#23120](https://core.trac.wordpress.org/ticket/23120#comment:46) (There should be indication that widget settings have been saved).
+* Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28).
+* Add `Form.notifications`, copying from `props.model.notifications` if it exists.
+
+Changed (*Breaking!*):
+
+* Remove the passing of the `WidgetControl` as a `control` property when constructing a `Form`; instead pass the `model`
+  which can be a `Setting` or a plain `Value`.
+* Replace `wp.customize.Widgets.formConstructor` with `wp.widgets.formConstructor`.
+* Replace `wp.customize.Widgets.Form` with `wp.widgets.Form`.
+* Eliminate exporting all form configs to `CustomizeJSWidgets.data.form_configs` and instead attach to `From` prototypes on `wp.widgets.formConstructor`.
 * Rename script handles to be more appropriate.
+* Reduce duplicated code for rendering form templates; converts/renames `WP_JS_Widget::form_template()` into wrapper method `WP_JS_Widget::render_form_template_scripts()` which outputs the script tags. Splits out form template contents into `WP_JS_Widget::render_form_template()`.
+* Eliminates extraneous `id_base` property for JS `Form` class, adding `template_id` form config which is then sourced from a new `WP_JS_Widget::get_form_template_id()`, which in turn is used by `WP_JS_Widget::render_form_template_scripts()` and is used in the JS `Form#getTemplate` method.
+* Replace `name` arg with `field` arg in calls to `WP_JS_Widget::render_form_field_template()`. Ensure that rendered field templates use a random `name` for each `input` to prevent collisions with other widgets. Store `field` in `data-field` attribute.
+* Deprecated `WP_JS_Widget::get_form_args()` in favor of `WP_JS_Widget::get_form_config()`.
+
+Fixed:
+
+* Fix initialization of Pages widget in how it amends the default config.
 * Fix PHP warning for array to string conversion in Pages widget.
 * Prevent RSS widget from showing error when feed URL is empty.
-* Reduce duplicated code for rendering form templates.
-* *Breaking change:* Converts/renames WP_JS_Widget::form_template() into wrapper method `WP_JS_Widget::render_form_template_scripts()` which outputs the script tags.
-* Splits out form template contents into `WP_JS_Widget::render_form_template()`.
-* Eliminates extraneous `id_base` property for JS Form class, adding `template_id` form config which is then sourced from a new `WP_JS_Widget::get_form_template_id()`, which in turn is used by `WP_JS_Widget::render_form_template_scripts()` and is used in the JS `Form#getTemplate` method.
-* Ensure that notifications for the setting (model) render even when the form is embedded outside the customizer.
+* Ensure exclude object selector is initialized with array for Pages widgets.
+
+See [issues and PRs in milestone](https://github.com/xwp/wp-js-widgets/milestone/1?closed=1) and [full release commit log](https://github.com/xwp/wp-js-widgets/compare/0.2.0...0.3.0).
+
+See also updated [Customizer Object Selector](https://wordpress.org/plugins/customize-object-selector/) and [Next Recent Posts Widget](https://github.com/xwp/wp-next-recent-posts-widget) plugins.
 
 ### 0.2.0 - 2017-01-02 ###
 * Important: Update minimum WordPress core version to 4.7.0.

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ The next generation of widgets in core, embracing JS for UI and powering the Wid
 
 Also could be known as Widget Customizer 2.0, Widgets 3.0, or Widgets Next Generation.
 
+*Warning:* The APIs provided by this plugin are still in flux. If creating new widgets that extend the `WP_JS_Widget` class, please look at the changelog and ensure compatibility with your extended widgets before deploying.
+
 This plugin implements:
 
 * [WP-CORE#33507](https://core.trac.wordpress.org/ticket/33507): Allow widget controls to be JS-driven.

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,27 @@ Limitations/Caveats:
 
 == Changelog ==
 
+= 0.3.0 - 2017-01-?? (Unreleased) =
+
+* *Remove forms dependency on customize-widgets; allow standalone forms to allow for Shortcake or frontend integrations* (PR [#26](https://github.com/xwp/wp-js-widgets/pull/26))
+* Remove forms dependency on `customize-widgets.js` to allow standalone forms to allow for Shortcake or frontend integrations.
+* Remove the passing of the `WidgetControl` as a property when constructing a Form; instead pass the model
+  (which can be a Setting or a Value) and id_base directly, the latter of which should already be located
+  on the Form prototype along with the config.
+* Replace `wp.customize.Widgets.formConstructor` with `wp.widgets.formConstructor`
+* Replace `wp.customize.Widgets.Form` with `wp.widgets.Form`
+* Eliminate exporting all form configs to CustomizeJSWidgets.data.form_configs and instead attach to From prototypes.
+* Fix initialization of Pages widget in how it amends the default config.
+* Add Form.notifications
+* Rename script handles to be more appropriate.
+* Fix PHP warning for array to string conversion in Pages widget.
+* Prevent RSS widget from showing error when feed URL is empty.
+* Reduce duplicated code for rendering form templates.
+* *Breaking change:* Converts/renames WP_JS_Widget::form_template() into wrapper method `WP_JS_Widget::render_form_template_scripts()` which outputs the script tags.
+* Splits out form template contents into `WP_JS_Widget::render_form_template()`.
+* Eliminates extraneous `id_base` property for JS Form class, adding `template_id` form config which is then sourced from a new `WP_JS_Widget::get_form_template_id()`, which in turn is used by `WP_JS_Widget::render_form_template_scripts()` and is used in the JS `Form#getTemplate` method.
+* Ensure that notifications for the setting (model) render even when the form is embedded outside the customizer.
+
 = 0.2.0 - 2017-01-02 =
 
 * Important: Update minimum WordPress core version to 4.7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -47,14 +47,14 @@ Limitations/Caveats:
 
 == Changelog ==
 
-= 0.3.0 - 2017-01-09 =
+= 0.3.0 - 2017-01-11 =
 
 Added:
 
 * Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (see [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
 * Render widget forms on widgets admin screen instead of directing the widgets to be edited in the customizer. PR [#27](https://github.com/xwp/wp-js-widgets/pull/27).
 * Improve UX of Save button on for a widget on the widgets admin screen to show as disabled and “Saved” if setting is not dirty. See [wpcore#23120](https://core.trac.wordpress.org/ticket/23120#comment:46) (There should be indication that widget settings have been saved).
-* Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28).
+* Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28) and [#31](https://github.com/xwp/wp-js-widgets/pull/31).
 * Add `Form.notifications`, copying from `props.model.notifications` if it exists.
 
 Changed (*Breaking!*):

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ The next generation of widgets in core, embracing JS for UI and powering the Wid
 
 Also could be known as Widget Customizer 2.0, Widgets 3.0, or Widgets Next Generation.
 
+*Warning:* The APIs provided by this plugin are still in flux. If creating new widgets that extend the `WP_JS_Widget` class, please look at the changelog and ensure compatibility with your extended widgets before deploying.
+
 This plugin implements:
 
 * [WP-CORE#33507](https://core.trac.wordpress.org/ticket/33507): Allow widget controls to be JS-driven.

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Limitations/Caveats:
 
 Added:
 
-* Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (See [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
+* Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (see [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
 * Render widget forms on widgets admin screen instead of directing the widgets to be edited in the customizer. PR [#27](https://github.com/xwp/wp-js-widgets/pull/27).
 * Improve UX of Save button on for a widget on the widgets admin screen to show as disabled and “Saved” if setting is not dirty. See [wpcore#23120](https://core.trac.wordpress.org/ticket/23120#comment:46) (There should be indication that widget settings have been saved).
 * Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      xwp, westonruter
 Tags:              customizer, widgets, rest-api
 Requires at least: 4.7.0
 Tested up to:      4.7.0
-Stable tag:        0.2.0
+Stable tag:        0.3.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,26 +47,39 @@ Limitations/Caveats:
 
 == Changelog ==
 
-= 0.3.0 - 2017-01-?? (Unreleased) =
+= 0.3.0 - 2017-01-09 =
 
-* *Remove forms dependency on customize-widgets; allow standalone forms to allow for Shortcake or frontend integrations* (PR [#26](https://github.com/xwp/wp-js-widgets/pull/26))
-* Remove forms dependency on `customize-widgets.js` to allow standalone forms to allow for Shortcake or frontend integrations.
-* Remove the passing of the `WidgetControl` as a property when constructing a Form; instead pass the model
-  (which can be a Setting or a Value) and id_base directly, the latter of which should already be located
-  on the Form prototype along with the config.
-* Replace `wp.customize.Widgets.formConstructor` with `wp.widgets.formConstructor`
-* Replace `wp.customize.Widgets.Form` with `wp.widgets.Form`
-* Eliminate exporting all form configs to CustomizeJSWidgets.data.form_configs and instead attach to From prototypes.
-* Fix initialization of Pages widget in how it amends the default config.
-* Add Form.notifications
+Added:
+
+* Allow widget forms to be constructed standalone, outside the customizer. This allows forms to appear on widgets admin screen, and will allow Shortcake (See [#11](https://github.com/xwp/wp-js-widgets/issue/11)) and frontend integrations. Removes forms dependency on `customize-widgets.js`. PR [#26](https://github.com/xwp/wp-js-widgets/pull/26).
+* Render widget forms on widgets admin screen instead of directing the widgets to be edited in the customizer. PR [#27](https://github.com/xwp/wp-js-widgets/pull/27).
+* Improve UX of Save button on for a widget on the widgets admin screen to show as disabled and “Saved” if setting is not dirty. See [wpcore#23120](https://core.trac.wordpress.org/ticket/23120#comment:46) (There should be indication that widget settings have been saved).
+* Introduce `field` arg for `WP_JS_Widget::render_form_field_template()` which connects a rendered field template to the field in the item schema, allowing the field attributes to be automatically derived from the schema. PR [#28](https://github.com/xwp/wp-js-widgets/pull/28).
+* Add `Form.notifications`, copying from `props.model.notifications` if it exists.
+
+Changed (*Breaking!*):
+
+* Remove the passing of the `WidgetControl` as a `control` property when constructing a `Form`; instead pass the `model`
+  which can be a `Setting` or a plain `Value`.
+* Replace `wp.customize.Widgets.formConstructor` with `wp.widgets.formConstructor`.
+* Replace `wp.customize.Widgets.Form` with `wp.widgets.Form`.
+* Eliminate exporting all form configs to `CustomizeJSWidgets.data.form_configs` and instead attach to `From` prototypes on `wp.widgets.formConstructor`.
 * Rename script handles to be more appropriate.
+* Reduce duplicated code for rendering form templates; converts/renames `WP_JS_Widget::form_template()` into wrapper method `WP_JS_Widget::render_form_template_scripts()` which outputs the script tags. Splits out form template contents into `WP_JS_Widget::render_form_template()`.
+* Eliminates extraneous `id_base` property for JS `Form` class, adding `template_id` form config which is then sourced from a new `WP_JS_Widget::get_form_template_id()`, which in turn is used by `WP_JS_Widget::render_form_template_scripts()` and is used in the JS `Form#getTemplate` method.
+* Replace `name` arg with `field` arg in calls to `WP_JS_Widget::render_form_field_template()`. Ensure that rendered field templates use a random `name` for each `input` to prevent collisions with other widgets. Store `field` in `data-field` attribute.
+* Deprecated `WP_JS_Widget::get_form_args()` in favor of `WP_JS_Widget::get_form_config()`.
+
+Fixed:
+
+* Fix initialization of Pages widget in how it amends the default config.
 * Fix PHP warning for array to string conversion in Pages widget.
 * Prevent RSS widget from showing error when feed URL is empty.
-* Reduce duplicated code for rendering form templates.
-* *Breaking change:* Converts/renames WP_JS_Widget::form_template() into wrapper method `WP_JS_Widget::render_form_template_scripts()` which outputs the script tags.
-* Splits out form template contents into `WP_JS_Widget::render_form_template()`.
-* Eliminates extraneous `id_base` property for JS Form class, adding `template_id` form config which is then sourced from a new `WP_JS_Widget::get_form_template_id()`, which in turn is used by `WP_JS_Widget::render_form_template_scripts()` and is used in the JS `Form#getTemplate` method.
-* Ensure that notifications for the setting (model) render even when the form is embedded outside the customizer.
+* Ensure exclude object selector is initialized with array for Pages widgets.
+
+See [issues and PRs in milestone](https://github.com/xwp/wp-js-widgets/milestone/1?closed=1) and [full release commit log](https://github.com/xwp/wp-js-widgets/compare/0.2.0...0.3.0).
+
+See also updated [Customizer Object Selector](https://wordpress.org/plugins/customize-object-selector/) and [Next Recent Posts Widget](https://github.com/xwp/wp-next-recent-posts-widget) plugins.
 
 = 0.2.0 - 2017-01-02 =
 


### PR DESCRIPTION
- [x] Add contributor props.
- [x] Bump version numbers. `ack -Q 0.2.0` and replace with `0.3.0` where appropriate (this needs to be automated)
- [x] Add changelog to readme.
- [x] [Draft new GitHub release](https://github.com/xwp/wp-js-widgets/releases/new?tag=0.3.0) tag `0.3.0` on `master`
- [x] Test build.
- [x] Add to drafted release a ZIP build via `grunt build; cd build; zip -r ../js-widgets-0.3.0.zip *; cd -; mv js-widgets-0.3.0.zip ~/Downloads`, and with link to readme on tag tree: https://github.com/xwp/wp-js-widgets/blob/0.3.0/readme.md#changelog
- [x] Merge release PR.
- [ ] Wait for Travis build to go ✅ .
- [x] Deploy to WordPress.org via `grunt deploy`. Remember to look at SVN diff.
- [x] Publish GitHub release.
- [x] Close GitHub milestone.
