### PR TITLE
Release 0.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-js-widgets",
 	"description": "The next generation of widgets in Core (Widgets 3.0), embracing JS for UI and powering the Widgets REST API.",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"type": "wordpress-plugin",
 	"keywords": [ "customizer", "widgets", "rest-api" ],
 	"homepage": "https://github.com/xwp/wp-js-widgets/",

--- a/core-adapter-widgets/pages/class.php
+++ b/core-adapter-widgets/pages/class.php
@@ -104,7 +104,7 @@ class WP_JS_Widget_Pages extends WP_Adapter_JS_Widget {
 		if ( is_array( $default_instance['exclude'] ) ) {
 			$default_instance['exclude'] = join( ',', $default_instance['exclude'] );
 		}
-		if ( is_array( $new_instance['exclude'] ) ) {
+		if ( isset( $new_instance['exclude'] ) && is_array( $new_instance['exclude'] ) ) {
 			$new_instance['exclude'] = join( ',', $new_instance['exclude'] );
 		}
 		$new_instance = array_merge( $default_instance, $new_instance );

--- a/core-adapter-widgets/pages/form.js
+++ b/core-adapter-widgets/pages/form.js
@@ -50,7 +50,8 @@ wp.widgets.formConstructor.pages = (function( api ) {
 						multiple: true,
 						width: '100%'
 					},
-					select_id: form.config.exclude_select_id
+					select_id: form.config.exclude_select_id,
+					show_add_buttons: false
 				});
 				selectorContainer = form.container.find( '.customize-object-selector-container:first' );
 				form.postObjectSelector.embed( selectorContainer );

--- a/js-widgets.php
+++ b/js-widgets.php
@@ -3,7 +3,7 @@
  * Plugin Name: JS Widgets
  * Description: The next generation of widgets in core, embracing JS for UI and powering the Widgets REST API.
  * Plugin URI: https://github.com/xwp/wp-js-widgets/
- * Version: 0.4.0
+ * Version: 0.4.1
  * Author: XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/xwp/wp-js-widgets.git"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "GPL-2.0+",
   "private": true,
   "devDependencies": {

--- a/post-collection-widget.php
+++ b/post-collection-widget.php
@@ -3,7 +3,7 @@
  * Plugin Name: JS Widgets: Post Collection Widget
  * Description: A widget allowing for featuring a curated list of posts.
  * Plugin URI: https://github.com/xwp/wp-js-widgets/
- * Version: 0.4.0
+ * Version: 0.4.1
  * Author: XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,12 @@ Limitations/Caveats:
 
 ## Changelog ##
 
+### 0.4.1 - 2017-02-20 ###
+* Fix undefined index warning in Pages widget. See [#40](https://github.com/xwp/wp-js-widgets/pull/40).
+* Disable the "Add" button for the page selector field as provided by the Customize Object Selector plugin when Customize Posts is also active.
+
+See <a href="https://github.com/xwp/wp-js-widgets/milestone/3?closed=1">issues and PRs in milestone</a> and <a href="https://github.com/xwp/wp-js-widgets/compare/0.4.0...0.4.1">full release commit log</a>.
+
 ### 0.4.0 - 2017-02-17 ###
 * Integrate with [Shortcake (Shortcode UI)](https://wordpress.org/plugins/shortcode-ui/) to allow any JS widget to be used inside the editor as a Post Element. See [#11](https://github.com/xwp/wp-js-widgets/issues/11), [#32](https://github.com/xwp/wp-js-widgets/pull/32).
 * Refactor of `Form` along with introduction of JS unit tests. See [#35](https://github.com/xwp/wp-js-widgets/pull/35). Props [sirbrillig](https://profiles.wordpress.org/sirbrillig)!

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,13 @@ Limitations/Caveats:
 
 == Changelog ==
 
+= 0.4.1 - 2017-02-20 =
+
+* Fix undefined index warning in Pages widget. See [#40](https://github.com/xwp/wp-js-widgets/pull/40).
+* Disable the "Add" button for the page selector field as provided by the Customize Object Selector plugin when Customize Posts is also active.
+
+See <a href="https://github.com/xwp/wp-js-widgets/milestone/3?closed=1">issues and PRs in milestone</a> and <a href="https://github.com/xwp/wp-js-widgets/compare/0.4.0...0.4.1">full release commit log</a>.
+
 = 0.4.0 - 2017-02-17 =
 
 * Integrate with [Shortcake (Shortcode UI)](https://wordpress.org/plugins/shortcode-ui/) to allow any JS widget to be used inside the editor as a Post Element. See [#11](https://github.com/xwp/wp-js-widgets/issues/11), [#32](https://github.com/xwp/wp-js-widgets/pull/32).


### PR DESCRIPTION
- [x] Add contributor props.
- [x] Bump version numbers. `ack -Q 0.4.0` and replace with `0.4.1` where appropriate (this needs to be automated)
- [x] Add changelog to readme.
- [x] Test build`grunt build; cd build; zip -r ../js-widgets-0.4.1.zip *; cd -; mv js-widgets-0.4.1.zip ~/Downloads` and install via uploading plugin via WP Admin.
- [x] [Draft new GitHub release](https://github.com/xwp/wp-js-widgets/releases/new?tag=0.4.1) tag `0.4.1` on `master`
- [x] Add to drafted release a ZIP build with link to readme on tag tree: https://github.com/xwp/wp-js-widgets/blob/0.4.1/readme.md#changelog
- [x] Merge release PR.
- [x] Wait for Travis build for [`master` branch](https://travis-ci.org/xwp/wp-js-widgets/branches) to go ✅ .
- [x] Deploy to WordPress.org via `grunt deploy`. Remember to look at SVN diff.
- [x] Publish GitHub release.
- [x] Close GitHub milestone.
